### PR TITLE
Add module event_registration_add_by_partner.

### DIFF
--- a/event_registration_add_by_partner/README.rst
+++ b/event_registration_add_by_partner/README.rst
@@ -1,0 +1,50 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Add event registrations by partner
+==================================
+
+This module was written to extend the functionality of events to support
+setting the partner that is linked to a registration directly in the event
+form, without needing to open the registration form.
+
+Usage
+=====
+
+To use this module, you need to:
+
+* Open an event.
+* In the *Registrations* page, add a new registration.
+* Select a partner from the database and other fields should be autofilled.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/event/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/event/issues/new?body=module:%20event_registration_add_by_partner%0Aversion:%208.0.1.0.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* `Grupo ESOC <http://grupoesoc.es>`_:
+    * `Jairo Llopis <mailto:j.llopis@grupoesoc.es>`_.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/event_registration_add_by_partner/__openerp__.py
+++ b/event_registration_add_by_partner/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# © 2015 Grupo ESOC Ingeniería de Servicios, S.L.U.
+
+{
+    "name": "Add event registrations by partner",
+    "version": "8.0.1.0.0",
+    "category": "Project",
+    "author": "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "http://www.grupoesoc.es",
+    "summary": "Allow setting the partner when adding a registration",
+    "depends": [
+        "event",
+    ],
+    "data": [
+        "views/event_event_views.xml",
+    ],
+}

--- a/event_registration_add_by_partner/views/event_event_views.xml
+++ b/event_registration_add_by_partner/views/event_event_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+     © 2015 Grupo ESOC Ingeniería de Servicios, S.L.U. -->
+
+<openerp>
+<data>
+
+<record id="event_event_view_form" model="ir.ui.view">
+    <field name="name">Add registrations by partner</field>
+    <field name="model">event.event</field>
+    <field name="inherit_id" ref="event.view_event_form"/>
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='registration_ids']
+                         //field[@name='name']"
+                   position="before">
+                <field name="partner_id"/>
+            </xpath>
+        </data>
+    </field>
+</record>
+
+</data>
+</openerp>


### PR DESCRIPTION
Aiming for https://github.com/OCA/l10n-spain/issues/174, this module will make it easier to add partners from the database as event attendants.

Odoo's default behavior is to write manually the name of each attendant from the event form, and if you want to link it to a database partner, then you must go to the attendants subform and do it from there.

This module allows that behavior, but also allows adding the name from a database partner from the main form. It's easier and less confusing for end users.
