### PR TITLE
[FIX] XML view error

### DIFF
--- a/event_registration_mass_mailing/views/event_registration.xml
+++ b/event_registration_mass_mailing/views/event_registration.xml
@@ -64,9 +64,9 @@
     <field name="model">event.registration</field>
     <field name="inherit_id" ref="event.view_event_registration_form"/>
     <field name="arch" type="xml">
-        <label for="email" position="before">
+        <field name="email" position="before">
             <field name="opt_out"/>
-        </label>
+        </field>
     </field>
 </record>
 


### PR DESCRIPTION
Fix error while installing this addon:

```
ParseError: "ValidateError
El(los) campo(s) `arch` fallaron contra la restricci\xf3n: Invalid view definition

Detalles de error:
El elemento '<label for="email">' no puede ser localizado en la vista padre

Error de contexto:
Vista `Marketing - Registrations Form`
[view_id: 2546, xml_id: n/a, model: event.registration, parent_id: 1131]" while parsing /xxx/event_registration_mass_mailing/views/event_registration.xml:62, near
<record id="view_event_registration_form" model="ir.ui.view">
    <field name="name">Marketing - Registrations Form</field>
    <field name="model">event.registration</field>
    <field name="inherit_id" ref="event.view_event_registration_form"/>
    <field name="arch" type="xml">
        <label for="email" position="before">
            <field name="opt_out"/>
        </label>
    </field>
</record>
```

We have to match using field, not label. I don't know how could it pass travis.
This error is because  `event.view_event_registration_form` view has chaged here: https://github.com/odoo/odoo/commit/9717afbbb72638b43037bc6c304a2d15f7dc3f20
