### PR TITLE
[8.0][partner_event] Fix bug when using wrong type to browse record.

### DIFF
--- a/partner_event/models/event_registration.py
+++ b/partner_event/models/event_registration.py
@@ -26,7 +26,7 @@ class EventRegistration(models.Model):
             email = vals.get('email').replace('%', '').replace('_', '\\_')
             partners = partner_model.search(
                 [('email', '=ilike', email)])
-            event = event_model.browse(vals['event_id'])
+            event = event_model.browse(int(vals['event_id']))
             if partners:
                 partner_id = partners[0].id
                 vals['name'] = vals.get('name') or partners[0].name


### PR DESCRIPTION
I was getting this error:

```
Traceback (most recent call last):
  File "/opt/odoo/common/openerp/v8/addons/website/models/ir_http.py", line 199, in _handle_exception
    response = super(ir_http, self)._handle_exception(exception)
  File "/opt/odoo/common/openerp/v8/openerp/addons/base/ir/ir_http.py", line 145, in _handle_exception
    return request._handle_exception(exception)
  File "/opt/odoo/common/openerp/v8/openerp/http.py", line 666, in _handle_exception
    return super(HttpRequest, self)._handle_exception(exception)
  File "/opt/odoo/common/openerp/v8/openerp/addons/base/ir/ir_http.py", line 171, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/common/openerp/v8/openerp/http.py", line 684, in dispatch
    r = self._call_function(**self.params)
  File "/opt/odoo/common/openerp/v8/openerp/http.py", line 310, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/common/openerp/v8/openerp/service/model.py", line 118, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/common/openerp/v8/openerp/http.py", line 307, in checked_call
    return self.endpoint(*a, **kw)
  File "/opt/odoo/common/openerp/v8/openerp/http.py", line 803, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/common/openerp/v8/openerp/http.py", line 403, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/0508_entradasymas_openerp/oca/website_event_register_free_with_sale/controllers/website_sale.py", line 79, in confirm_order
    registration = reg_obj.sudo().create(registration_vals)
  File "/opt/odoo/common/openerp/v8/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/0508_entradasymas_openerp/extras/eym_custom/models/event_registration.py", line 79, in create
    return super(EventRegistration, self).create(vals)
  File "/opt/odoo/common/openerp/v8/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/0508_entradasymas_openerp/oca/partner_event/models/event_registration.py", line 34, in create
    elif event.create_partner:
  File "/opt/odoo/common/openerp/v8/openerp/fields.py", line 819, in __get__
    self.determine_value(record)
  File "/opt/odoo/common/openerp/v8/openerp/fields.py", line 912, in determine_value
    record._prefetch_field(self)
  File "/opt/odoo/common/openerp/v8/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/common/openerp/v8/openerp/models.py", line 3258, in _prefetch_field
    result = self.read(list(fnames), load='_classic_write')
  File "/opt/odoo/common/openerp/v8/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/common/openerp/v8/openerp/models.py", line 3192, in read
    self._read_from_database(stored, inherited)
  File "/opt/odoo/common/openerp/v8/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/common/openerp/v8/openerp/models.py", line 3406, in _read_from_database
    ', '.join(map(repr, extras._ids)),
AccessError: ('AccessError', u"Database fetch misses ids (u'14967') and has extra ids (14967), may be caused by a type incoherence in a previous request")
```

This 1-line patch fixes that ensuring always that event id is `int`.

To test if this works, just buy a ticket.

CC @rafaelbn @JavierIniesta.
