### PR TITLE
[FIX] Bufixes in event to project sync

### DIFF
--- a/event_project/views/event_event_view.xml
+++ b/event_project/views/event_event_view.xml
@@ -23,7 +23,8 @@
                     name="%(action_project_template_wizard)d" type="action"/>
         </button>
         <field name="date_tz" position="after">
-            <field name="project_id"/>
+            <field name="project_id"
+                   domain="[('event_id', '=', False), ('state', 'not in', ('template', 'cancelled', 'close'))]"/>
         </field>
         <div class="oe_right oe_button_box" position="inside">
             <button name="%(act_event_task_list)d"


### PR DESCRIPTION
Fixes:
- Set `project.event_id` to `False` when removing project from event
- Set `project.event_id` properly when creating project from template
- Set a restricted domain to `event.project_id` field in order to show only live projects without a event associated
