### PR TITLE
Make no type count as a type.

### DIFF
--- a/event_registration_cancel_reason/tests/test_event_registration_cancel_reason.py
+++ b/event_registration_cancel_reason/tests/test_event_registration_cancel_reason.py
@@ -44,3 +44,11 @@ class TestEventRegistrationCancelReason(common.TransactionCase):
             self.wizard_model.with_context(
                 active_ids=self.registrations.ids).create(
                 {'reason_id': self.cancel_reason.id})
+
+    def test_cancel_one_event_without_type(self):
+        """Registration cancel from 2 events (1 typed, 1 not) are aborted."""
+        self.event2.type = False
+        with self.assertRaises(exceptions.ValidationError):
+            self.wizard_model.with_context(
+                active_ids=self.registrations.ids).create(
+                {'reason_id': self.cancel_reason.id})

--- a/event_registration_cancel_reason/wizard/event_registration_cancel_log_reason.py
+++ b/event_registration_cancel_reason/wizard/event_registration_cancel_log_reason.py
@@ -23,7 +23,7 @@ class EventRegistrationCancelLogReason(models.TransientModel):
             var_fields)
         registrations = self.env['event.registration'].browse(
             self.env.context['active_ids'])
-        first_type = registrations[0].event_id.type
+        first_type = registrations[:1].event_id.type
         for event in registrations.mapped("event_id"):
             if event.type != first_type:
                 raise exceptions.ValidationError(

--- a/event_registration_cancel_reason/wizard/event_registration_cancel_log_reason.py
+++ b/event_registration_cancel_reason/wizard/event_registration_cancel_log_reason.py
@@ -23,12 +23,13 @@ class EventRegistrationCancelLogReason(models.TransientModel):
             var_fields)
         registrations = self.env['event.registration'].browse(
             self.env.context['active_ids'])
-        event_type = registrations.mapped("event_id.type")
-        if len(event_type) != 1:
-            raise exceptions.ValidationError(
-                _("You cannot cancel registrations from events of different "
-                  "types at once."))
-        res['event_type_id'] = event_type.id
+        first_type = registrations[0].event_id.type
+        for event in registrations.mapped("event_id"):
+            if event.type != first_type:
+                raise exceptions.ValidationError(
+                    _("You cannot cancel registrations from events of "
+                      "different types at once."))
+        res['event_type_id'] = first_type.id
         return res
 
     @api.multi


### PR DESCRIPTION
Fix #35. When an event had no type, it was not getting in the mapping because of the way Odoo generates recordsets.

@rafaelbn @pedrobaeza 
