### PR TITLE
[8.0][event_sale_registration_partner_unique] No problems with event_sale

### DIFF
--- a/event_sale_registration_partner_unique/README.rst
+++ b/event_sale_registration_partner_unique/README.rst
@@ -1,0 +1,79 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================================================
+Unique Partner per Event, Combined With Event Sales
+===================================================
+
+This module avoids duplicates when you confirm several sale orders for a same
+customer and event.
+
+In case you sell different ticket types, the duplicate is however allowed, but
+not the combination of event + partner + ticket.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to *Marketing > Events > Create*.
+#. Enable *Forbid duplicates*.
+#. Try to create 2 registrations for the same partner and ticket in this event.
+#. You cannot.
+#. Go to *Sales > Sales > Sales Orders*.
+#. Create a new sale order for customer "A".
+#. Add a new line with:
+    - Product: Choose a event ticket product.
+    - Event: Choose an event for that product.
+    - Ticket: Choose a ticket type if you want.
+    - Quantity: 1.
+#. Confirm the sale order.
+#. Enter the event and check it has 1 registration with 1 seat.
+#. Go back to the sale order, duplicate it and confirm it.
+#. Go back to the event again, it has 1 registration with 2 seats.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/199/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/event/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+event/issues/new?body=module:%20
+event_sale_registration_partner_unique%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Rafael Blasco <rafabn@antiun.com>
+* Jairo Llopis <yajo.sk8@gmail.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/event_sale_registration_partner_unique/__init__.py
+++ b/event_sale_registration_partner_unique/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/event_sale_registration_partner_unique/__openerp__.py
+++ b/event_sale_registration_partner_unique/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Unique Partner per Event, Combined With Event Sales",
+    "summary": "Makes event sales not to duplicate registrations",
+    "version": "8.0.1.0.0",
+    "category": "Events",
+    "website": "http://www.antiun.com",
+    "author": "Antiun Ingeniería S.L., Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "autoinstall": True,
+    "depends": [
+        "event_registration_partner_unique",
+        "event_sale",
+    ],
+}

--- a/event_sale_registration_partner_unique/i18n/es.po
+++ b/event_sale_registration_partner_unique/i18n/es.po
@@ -1,0 +1,24 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* event_registration_partner_unique
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-03 17:59+0100\n"
+"PO-Revision-Date: 2016-03-03 17:59+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.8.6\n"
+
+#. module: event_registration_partner_unique
+#: code:addons/event_registration_partner_unique/models/sale_order.py:32
+#, python-format
+msgid "%d new registrations sold in %s."
+msgstr "%d nuevos registros vendidos en %s."

--- a/event_sale_registration_partner_unique/models/__init__.py
+++ b/event_sale_registration_partner_unique/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import event, sale_order

--- a/event_sale_registration_partner_unique/models/event.py
+++ b/event_sale_registration_partner_unique/models/event.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, models
+
+
+class EventRegistration(models.Model):
+    _inherit = "event.registration"
+
+    @api.multi
+    def _duplicate_search_domain(self):
+        """Look for tickets too."""
+        result = super(EventRegistration, self)._duplicate_search_domain()
+        result.append(("event_ticket_id", "=", self.event_ticket_id.id))
+        return result

--- a/event_sale_registration_partner_unique/models/sale_order.py
+++ b/event_sale_registration_partner_unique/models/sale_order.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import _, api, models
+from openerp.addons.event_registration_partner_unique import exceptions
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    @api.multi
+    def button_confirm(self):
+        """Add registrations to the already existing record if possible."""
+        for s in self:
+            try:
+                with self.env.cr.savepoint():
+                    super(SaleOrderLine, s).button_confirm()
+
+            # A registration already exists
+            except exceptions.DuplicatedPartnerError as error:
+                regs = error._kwargs["registrations"].with_context(
+                    mail_create_nolog=True)
+                qty = int(s.product_uom_qty)
+                for reg in regs:
+                    reg.nb_register += qty
+                regs.message_post(_("%d new registrations sold in %s.") %
+                                  (qty, s.order_id.display_name))
+
+        return True

--- a/event_sale_registration_partner_unique/tests/__init__.py
+++ b/event_sale_registration_partner_unique/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_sale_order

--- a/event_sale_registration_partner_unique/tests/test_sale_order.py
+++ b/event_sale_registration_partner_unique/tests/test_sale_order.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingeniería S.L. - Jairo Llopis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+
+
+class SomethingCase(TransactionCase):
+    def setUp(self, *args, **kwargs):
+        super(SomethingCase, self).setUp(*args, **kwargs)
+        self.partner = self.env.ref("base.res_partner_2")
+        self.event = self.env.ref("event.event_3")
+        self.event.forbid_duplicates = True
+        self.sale_order = self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+        })
+        self.sale_order.order_line |= self.env["sale.order.line"].create({
+            "order_id": self.sale_order.id,
+            "product_id": self.env.ref("event_sale.event_3_product").id,
+            "event_id": self.event.id,
+            "event_ticket_id": self.env.ref("event_sale.event_3_ticket_1").id,
+            "product_uom_qty": 1,
+            "price_unit": 1000,
+        })
+
+    def test_nodupe(self):
+        """Everything works as before without duplicates."""
+        self.sale_order.action_button_confirm()
+        self.assertEqual(self.event.registration_ids.partner_id, self.partner)
+        self.assertEqual(self.event.registration_ids.nb_register, 1)
+
+    def test_dupe(self):
+        """Everything works when duplicates are found."""
+        self.sale_order.action_button_confirm()
+        newso = self.sale_order.copy()
+        newso.action_button_confirm()
+        self.assertEqual(self.event.registration_ids.partner_id, self.partner)
+        self.assertEqual(self.event.registration_ids.nb_register, 2)
+
+    def test_dupe_different_ticket(self):
+        """Duplicates allowed when ticket type differs."""
+        self.sale_order.action_button_confirm()
+        newso1 = self.sale_order.copy()
+        newso1.order_line.event_ticket_id = False
+        newso1.action_button_confirm()
+        newso2 = newso1.copy()
+        newso2.action_button_confirm()
+        for r in self.event.registration_ids:
+            if r.event_ticket_id:
+                self.assertEqual(r.nb_register, 1)
+            else:
+                self.assertEqual(r.nb_register, 2)


### PR DESCRIPTION
This module combines the power of event_sale and event_registration_partner_unique to remove conflicts.

This is WIP until https://github.com/OCA/event/pull/38 is merged.

In case you confirm a sale order that would create a duplicate registration, then additional attendants are added to the already-existing registration, unless you are selling a different ticket type, in which case the duplicat partner is allowed (but not duplicate partner + ticket combinations).

@rafaelbn @antespi 
