### PR TITLE
[8.0][IMP][partner_event] Propagate partner changes and show errors when registering partners

### DIFF
--- a/partner_event/__init__.py
+++ b/partner_event/__init__.py
@@ -1,7 +1,8 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
 from . import wizard

--- a/partner_event/__openerp__.py
+++ b/partner_event/__openerp__.py
@@ -1,27 +1,8 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Odoo Source Management Solution
-#    Copyright (c) 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
-#                       Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-#    Copyright (c) 2015 Antiun Ingeniería S.L. (http://www.antiun.com)
-#                       Javier Iniesta <javieria@antiun.com>
-#                       Antonio Espinosa <antonioea@antiun.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Link partner to events',

--- a/partner_event/models/__init__.py
+++ b/partner_event/models/__init__.py
@@ -1,7 +1,8 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import event_event
 from . import event_registration

--- a/partner_event/models/event_event.py
+++ b/partner_event/models/event_event.py
@@ -1,7 +1,8 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields
 

--- a/partner_event/models/event_registration.py
+++ b/partner_event/models/event_registration.py
@@ -1,7 +1,8 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, api, fields
 

--- a/partner_event/models/event_registration.py
+++ b/partner_event/models/event_registration.py
@@ -45,7 +45,7 @@ class EventRegistration(models.Model):
         reg_fields = ['name', 'email', 'phone']
         reg_data = dict((k, v) for k, v in data.iteritems() if k in reg_fields)
         if reg_data:
-            for reg in self:
-                # Only update registration data if this event is not old
-                if reg.event_end_date >= fields.Datetime.now():
-                    reg.write(reg_data)
+            # Only update registration data if this event is not old
+            registrations = self.filtered(
+                lambda x: x.event_end_date >= fields.Datetime.now())
+            registrations.write(reg_data)

--- a/partner_event/models/event_registration.py
+++ b/partner_event/models/event_registration.py
@@ -3,7 +3,7 @@
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
 
-from openerp import models, api
+from openerp import models, api, fields
 
 
 class EventRegistration(models.Model):
@@ -38,3 +38,13 @@ class EventRegistration(models.Model):
                 partner_id = partner.id
             vals['partner_id'] = partner_id
         return super(EventRegistration, self).create(vals)
+
+    @api.multi
+    def partner_data_update(self, data):
+        reg_fields = ['name', 'email', 'phone']
+        reg_data = dict((k, v) for k, v in data.iteritems() if k in reg_fields)
+        if reg_data:
+            for reg in self:
+                # Only update registration data if this event is not old
+                if reg.event_end_date >= fields.Datetime.now():
+                    reg.write(reg_data)

--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -1,7 +1,8 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import api, fields, models
 

--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -17,12 +17,36 @@ class ResPartner(models.Model):
         compute='_compute_event_count',
         help="Count of events with confirmed registrations.",
     )
+    registration_count = fields.Integer(
+        string='Event registrations number', compute='_count_registration',
+        store=True)
+    attended_registration_count = fields.Integer(
+        string='Event attended registrations number',
+        compute='_count_attended_registration', store=True)
 
-    @api.one
-    @api.depends('registrations.state')
+    @api.multi
+    @api.depends('registrations')
+    def _count_registration(self):
+        for partner in self:
+            partner.registration_count = len(partner.registrations)
+
     def _compute_event_count(self):
         self.event_count = len(
             self.env["event.registration"].search([
                 ("partner_id", "child_of", self.id),
                 ("state", "not in", ("cancel", "draft")),
             ]).mapped("event_id"))
+
+    @api.multi
+    @api.depends('registrations.state')
+    def _count_attended_registration(self):
+        for partner in self:
+            partner.attended_registration_count = len(
+                partner.registrations.filtered(lambda x: x.state == 'done'))
+
+    @api.multi
+    def write(self, data):
+        res = super(ResPartner, self).write(data)
+        for partner in self:
+            partner.registrations.partner_data_update(data)
+        return res

--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -31,12 +31,14 @@ class ResPartner(models.Model):
         for partner in self:
             partner.registration_count = len(partner.registrations)
 
+    @api.multi
     def _compute_event_count(self):
-        self.event_count = len(
-            self.env["event.registration"].search([
-                ("partner_id", "child_of", self.id),
-                ("state", "not in", ("cancel", "draft")),
-            ]).mapped("event_id"))
+        for partner in self:
+            partner.event_count = len(
+                self.env["event.registration"].search([
+                    ("partner_id", "child_of", partner.id),
+                    ("state", "not in", ("cancel", "draft")),
+                ]).mapped("event_id"))
 
     @api.multi
     @api.depends('registrations.state')

--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -48,6 +48,5 @@ class ResPartner(models.Model):
     @api.multi
     def write(self, data):
         res = super(ResPartner, self).write(data)
-        for partner in self:
-            partner.registrations.partner_data_update(data)
+        self.mapped('registrations').partner_data_update(data)
         return res

--- a/partner_event/tests/__init__.py
+++ b/partner_event/tests/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-# License AGPL-3: Antiun Ingenieria S.L. - Javier Iniesta
-# See README.rst file on addon root folder for more details
+# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_event_registration

--- a/partner_event/tests/test_event_registration.py
+++ b/partner_event/tests/test_event_registration.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-# License AGPL-3: Antiun Ingenieria S.L. - Javier Iniesta
-# See README.rst file on addon root folder for more details
+# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp.tests.common import TransactionCase
 

--- a/partner_event/tests/test_event_registration.py
+++ b/partner_event/tests/test_event_registration.py
@@ -36,10 +36,12 @@ class TestEventRegistration(TransactionCase):
         event_1 = self.event_0.copy()
         self.assertEqual(self.partner_01.event_count, 0)
         self.registration_01.state = "open"
+        self.partner_01.invalidate_cache()
         self.assertEqual(self.partner_01.event_count, 1)
         self.registration_02.state = "done"
         self.registration_02.partner_id = self.partner_01
         self.registration_02.event_id = event_1
+        self.partner_01.invalidate_cache()
         self.assertEqual(self.partner_01.event_count, 2)
 
     def test_button_register(self):

--- a/partner_event/views/event_event_view.xml
+++ b/partner_event/views/event_event_view.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+     © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+     © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
 <openerp>
 <data>
 

--- a/partner_event/views/res_partner_view.xml
+++ b/partner_event/views/res_partner_view.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+     © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+     © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
 <openerp>
 <data>
 

--- a/partner_event/wizard/__init__.py
+++ b/partner_event/wizard/__init__.py
@@ -1,6 +1,7 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import res_partner_register_event

--- a/partner_event/wizard/res_partner_register_event.py
+++ b/partner_event/wizard/res_partner_register_event.py
@@ -1,7 +1,8 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields, api
 

--- a/partner_event/wizard/res_partner_register_event.py
+++ b/partner_event/wizard/res_partner_register_event.py
@@ -33,7 +33,7 @@ class ResPartnerRegisterEvent(models.TransientModel):
             partner = partner_obj.browse(partner_id)
             try:
                 with self.env.cr.savepoint():
-                    reg_id = registration_obj.create(
+                    registration_obj.create(
                         self._prepare_registration(partner))
             except:
                 errors.append(partner.name)

--- a/partner_event/wizard/res_partner_register_event_view.xml
+++ b/partner_event/wizard/res_partner_register_event_view.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+     © 2015 Antiun Ingenieria S.L. - Javier Iniesta
+     © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
 <openerp>
 <data>
 

--- a/partner_event/wizard/res_partner_register_event_view.xml
+++ b/partner_event/wizard/res_partner_register_event_view.xml
@@ -7,19 +7,31 @@
     <field name="model">res.partner.register.event</field>
     <field name="arch" type="xml">
         <form string="Select event to register">
-            <group>
+            <group attrs="{'invisible': [('errors', '!=', False)]}">
                 <field name="event"/>
             </group>
+            <group attrs="{'invisible': [('errors', '=', False)]}">
+                <label nolabel="1" colspan="4"
+                       string="These partners haven't been registered because they're already registered or other error occurred"/>
+                <field nolabel="1" name="errors" colspan="4"/>
+            </group>
             <footer>
-                <button name="button_register"
-                        type="object"
-                        string="Create registrations"
-                        class="oe_highlight"
-                        />
-                or
-                <button special="cancel"
-                        string="Cancel"
-                        />
+                <div attrs="{'invisible': [('errors', '!=', False)]}">
+                    <button name="button_register"
+                            type="object"
+                            string="Create registrations"
+                            class="oe_highlight"
+                            />
+                    or
+                    <button special="cancel"
+                            string="Cancel"
+                            />
+                </div>
+                <div attrs="{'invisible': [('errors', '=', False)]}">
+                    <button special="cancel"
+                            string="OK"
+                            />
+                </div>
             </footer>
         </form>
     </field>


### PR DESCRIPTION
This PR adds several improvements:
- When registering a selection of partners, maybe an exception can be reised. Then no partner is registered, although exception is referred to only one of them. This is common when combined with addon `event_registration_partner_unique`. Now, wizard register each partner inside a database savepoint and when finished shows partners that couldn't be registered.
- Change deprecated `@api.one` by `@api.multi` 
- Change registration partner data when partner form is updated (name, email and phone). But only if event is in future.
