### PR TITLE
[8.0][IMP][website_event_filter_selector] Add city filter for events.

### DIFF
--- a/website_event_filter_selector/README.rst
+++ b/website_event_filter_selector/README.rst
@@ -10,6 +10,9 @@ This module extends the functionality of the events website page to support
 using filters with dropdown selectors and allow you to choose between them and
 the core ones (left column).
 
+It also allows you to filter events by city, both in those new filters and
+using the old-style left column filters.
+
 Configuration
 =============
 

--- a/website_event_filter_selector/controllers/__init__.py
+++ b/website_event_filter_selector/controllers/__init__.py
@@ -2,4 +2,4 @@
 # © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import controllers, models
+from . import main

--- a/website_event_filter_selector/controllers/main.py
+++ b/website_event_filter_selector/controllers/main.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import _, http
+from openerp.addons.website_event.controllers.main import website_event
+
+
+class WebsiteEvent(website_event):
+    @http.route()
+    def events(self, page=1, **searches):
+        # Get current render values
+        searches.setdefault("city", "all")
+        values = super(WebsiteEvent, self).events(page, **searches).qcontext
+        searches = values["searches"]
+
+        # Regenerate current domain. Ideally, upstream would make all this in a
+        # separate method and make our life easier, but not happening now.
+        domain = [("state", "in", ("draft", "confirm", "done"))]
+
+        # Date domain
+        if values["current_date"]:
+            for date in values["dates"]:
+                if values["current_date"] == date[1]:
+                    domain += date[2]
+                    break
+
+        # Type domain
+        if values["current_type"]:
+            domain.append(("type", "=", values["current_type"].id))
+
+        # Country domain
+        if values["current_country"]:
+            domain.append(("country_id", "=", values["current_country"].id))
+        elif searches["country"] == 'online':
+            domain.append(("country_id", "=", False))
+
+        # Handle city search
+        event_obj = http.request.env["event.event"]
+        cities = event_obj.read_group(
+            domain,
+            ["city"],
+            groupby="city",
+            orderby="city")
+        cities.insert(0, {"city_count": len(values["event_ids"]),
+                          "city": _("All Cities"),
+                          "key": "all"})
+        if searches["city"] != "all":
+            domain.append(("city", "=", searches["city"]))
+        values["cities"] = cities
+        values["current_city"] = searches["city"]
+
+        # We need a new pager now
+        step = 10  # This is hardcoded upstream too
+        values["pager"] = http.request.website.pager(
+            url="/event",
+            url_args={
+                "date": searches.get("date"),
+                "type": searches.get("type"),
+                "country": searches.get("country"),
+                "city": searches.get("city"),
+            },
+            total=event_obj.search(domain, count=True),
+            page=page,
+            step=step,  # This is hardcoded upstream too
+            scope=5)
+
+        # Return new event results
+        order = 'website_published desc, date_begin'
+        if searches["date"] == "old":
+            order += " desc"
+        values["event_ids"] = event_obj.search(
+            domain,
+            limit=step,
+            offset=values["pager"]["offset"],
+            order=order)
+
+        # Render template again
+        return http.request.website.render("website_event.index", values)

--- a/website_event_filter_selector/models/__init__.py
+++ b/website_event_filter_selector/models/__init__.py
@@ -2,4 +2,4 @@
 # © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import controllers, models
+from . import event

--- a/website_event_filter_selector/models/event.py
+++ b/website_event_filter_selector/models/event.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# © 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import fields, models
+
+
+class EventEvent(models.Model):
+    _inherit = "event.event"
+
+    city = fields.Char(related="address_id.city", store=True)

--- a/website_event_filter_selector/views/templates.xml
+++ b/website_event_filter_selector/views/templates.xml
@@ -7,7 +7,7 @@
 
 <!-- Reusable callable templates -->
 <template id="element" name="Event Selection Filter Form Element">
-    <div t-att-id="element_id" t-attf-class="col-sm-#{element_span}">
+    <div t-att-id="element_id" t-attf-class="col-sm-#{12 / selection_filters_amount}">
         <div class="form-group">
             <t t-raw="0"/>
         </div>
@@ -17,7 +17,6 @@
 <template id="date" name="Event Date Selection Filter">
     <t t-call="website_event_filter_selector.element">
         <t t-set="element_id" t-value="filter_selector_date"/>
-        <t t-set="element_span" t-value="4"/>
         <label for="date">When</label>
         <select name="date" class="form-control">
             <t t-foreach="dates" t-as="date">
@@ -34,8 +33,7 @@
 <template id="country" name="Event Country Selection Filter">
     <t t-call="website_event_filter_selector.element">
         <t t-set="element_id" t-value="filter_selector_country"/>
-        <t t-set="element_span" t-value="4"/>
-        <label for="country">Where</label>
+        <label for="country">Country</label>
         <select name="country" class="form-control">
             <t t-foreach="countries" t-as="country">
                 <t t-if="country['country_id']">
@@ -55,10 +53,57 @@
     </t>
 </template>
 
+<template id="city" name="City Selection Filter">
+    <t t-call="website_event_filter_selector.element">
+        <t t-set="element_id" t-value="filter_selector_city"/>
+        <label for="city">City</label>
+        <select name="city" class="form-control">
+            <t t-foreach="cities" t-as="city">
+                <t t-if="city['city']">
+                    <t t-set="city_value"
+                       t-value="city.get('key', city['city'])"/>
+                    <option
+                        t-att-value="city_value"
+                        t-esc="'%s (%s)' % (
+                            city['city'],
+                            city['city_count'])"
+                        t-att-selected="city_value == current_city
+                                        and 'selected'"/>
+                </t>
+            </t>
+        </select>
+    </t>
+</template>
+
+<template
+    id="city_left_column"
+    inherit_id="website_event.event_left_column"
+    active="False"
+    customize_show="True"
+    name="Filter by City">
+    <xpath expr="//div[@id='left_column']" position="inside">
+        <ul class="nav nav-pills nav-stacked mt32">
+            <t t-foreach="cities" t-as="city">
+                <t t-if="city['city']">
+                    <t t-set="city_value"
+                       t-value="city.get('key', city['city'])"/>
+                    <li t-att-class="city_value == current_city and 'active'">
+                        <a t-attf-href="/event?{{ keep_query('country', 'date', 'type', city=city_value) }}">
+                            <t t-esc="city['city']"/>
+                            <span class="badge pull-right">
+                                <t t-esc="city['city_count']"/>
+                            </span>
+                        </a>
+                    </li>
+                </t>
+            </t>
+        </ul>
+    </xpath>
+</template>
+
 <template id="type" name="Event Type Selection Filter">
     <t t-call="website_event_filter_selector.element">
         <t t-set="element_id" t-value="filter_selector_date"/>
-        <t t-set="element_span" t-value="4"/>
         <label for="type">Event Type</label>
         <select name="type" class="form-control">
             <t t-foreach="types" t-as="type">
@@ -87,8 +132,10 @@
         <div id="website_event_filter_selector" class="mt8">
             <t id="custom"/>
             <form class="row" action="/event" method="GET">
+                <t t-set="selection_filters_amount" t-value="1"/>
                 <t id="filter_type"/>
                 <t id="filter_country"/>
+                <t id="filter_city"/>
                 <t id="filter_date"
                    t-call="website_event_filter_selector.date"/>
             </form>
@@ -100,6 +147,10 @@
           inherit_id="filter_date"
           name="Filter by Category"
           customize_show="True">
+    <xpath expr="//t[@t-set='selection_filters_amount']" position="after">
+        <t t-set="selection_filters_amount"
+           t-value="selection_filters_amount + 1"/>
+    </xpath>
     <xpath expr="//t[@id='filter_type']" position="attributes">
         <attribute name="t-call">website_event_filter_selector.type</attribute>
     </xpath>
@@ -109,8 +160,25 @@
           inherit_id="filter_date"
           name="Filter by Country"
           customize_show="True">
+    <xpath expr="//t[@t-set='selection_filters_amount']" position="after">
+        <t t-set="selection_filters_amount"
+           t-value="selection_filters_amount + 1"/>
+    </xpath>
     <xpath expr="//t[@id='filter_country']" position="attributes">
         <attribute name="t-call">website_event_filter_selector.country</attribute>
+    </xpath>
+</template>
+
+<template id="filter_city"
+          inherit_id="filter_date"
+          name="Filter by City"
+          customize_show="True">
+    <xpath expr="//t[@t-set='selection_filters_amount']" position="after">
+        <t t-set="selection_filters_amount"
+           t-value="selection_filters_amount + 1"/>
+    </xpath>
+    <xpath expr="//t[@id='filter_city']" position="attributes">
+        <attribute name="t-call">website_event_filter_selector.city</attribute>
     </xpath>
 </template>
 


### PR DESCRIPTION
Since this includes new logic, it adds also a template for left-column filters.

With this patch, you can now filter events depending on their cities, not only on their countries.

This also includes some modifications that will make filters occupy always a full bootstrap row, no matter if there are 1, 2, 3 or 4 filters, to avoid ugly layouts.

@pedrobaeza 
