### PR TITLE
[FIX] Add email != False to not_opt_out filter

### DIFF
--- a/event_registration_mass_mailing/__openerp__.py
+++ b/event_registration_mass_mailing/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': "Mass mailing from events",
     'category': 'Marketing',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.1.0',
     'depends': [
         'event',
         'mass_mailing'

--- a/event_registration_mass_mailing/views/event_registration.xml
+++ b/event_registration_mass_mailing/views/event_registration.xml
@@ -41,8 +41,8 @@
     <field name="arch" type="xml">
         <filter string="New" position="before">
             <filter string="Available for mass mailing"
-                name='not_opt_out' domain="[('opt_out', '=', False)]"
-                help="Registrations that did not ask not to be included in mass mailing campaigns"/>
+                name='not_opt_out' domain="[('opt_out', '=', False), ('email', '!=', False)]"
+                help="Registrations that did not ask not to be included in mass mailing campaigns and has an e-mail set."/>
             <separator/>
         </filter>
     </field>


### PR DESCRIPTION
When filtering `event.registration` objects for adding them to a mass.mailing, discard objects with no email defined, because they will fail when sending.
