### PR TITLE
[8.0][partner_event][FIX] Do not store registration counts.

### DIFF
--- a/partner_event/__openerp__.py
+++ b/partner_event/__openerp__.py
@@ -25,7 +25,7 @@
 
 {
     'name': 'Link partner to events',
-    'version': '8.0.1.1.0',
+    'version': '8.0.2.0.0',
     'category': 'Marketing',
     'author': 'Serv. Tecnol. Avanzados - Pedro M. Baeza, '
               'Antiun Ingeniería S.L., '

--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -13,11 +13,10 @@ class ResPartner(models.Model):
         string="Event registrations",
         comodel_name='event.registration', inverse_name="partner_id")
     registration_count = fields.Integer(
-        string='Event registrations number', compute='_count_registration',
-        store=True)
+        string='Event registrations number', compute='_count_registration')
     attended_registration_count = fields.Integer(
         string='Event attended registrations number',
-        compute='_count_attended_registration', store=True)
+        compute='_count_attended_registration')
 
     @api.one
     @api.depends('registrations')


### PR DESCRIPTION
These fields were stored. That usually is good, but if you add partners to an event from the wizard, it means each `res.partner` record gets its `registration_count` field updated.

When you update any record, fields `write_uid` and `write_date` are updated too.

Now imagine you want to add 4000 partners to an event. That would take time. If in the mean time any other user updates the `res.partner` record (along with their `write_UID` and `WRITE_DATE` fields), you would get this error:

```
openerp.sql_db: bad query: UPDATE "res_partner" SET "registration_count"=3,"write_uid"=5,"write_date"=(now() at time zone 'UTC') WHERE id IN (25578)
Traceback (most recent call last):
  File "/opt/odoo/common/openerp/v8/openerp/sql_db.py", line 234, in execute
    res = self._obj.execute(query, params)
TransactionRollbackError: could not serialize access due to concurrent update
CONTEXT:  SQL statement "SELECT 1 FROM ONLY "public"."res_users" x WHERE "id" OPERATOR(pg_catalog.=) $1 FOR KEY SHARE OF x"
```

By removing the `store=True` parameter, you simply avoid those concurrent updates and do not block other users.

But this changes the database structure, so remember to update your database!

@Tecnativa
