### PR TITLE
[8.0][IMP/FIX][partner_event] More sensible behavior.

### DIFF
--- a/partner_event/README.rst
+++ b/partner_event/README.rst
@@ -43,6 +43,10 @@ In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
 `here <https://github.com/OCA/event/issues/new?body=module:%20partner_event%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
+Known Issues / Roadmap
+======================
+
+* Remove some TODOs if https://github.com/odoo/odoo/pull/12997 is merged.
 
 Credits
 =======
@@ -53,6 +57,7 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Javier Iniesta <javieria@antiun.com>
 * Antonio Espinosa <antonioea@antiun.com>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/partner_event/__openerp__.py
+++ b/partner_event/__openerp__.py
@@ -25,18 +25,20 @@
 
 {
     'name': 'Link partner to events',
-    'version': '8.0.2.0.0',
+    'version': '8.0.3.0.0',
     'category': 'Marketing',
     'author': 'Serv. Tecnol. Avanzados - Pedro M. Baeza, '
               'Antiun Ingeniería S.L., '
+              'Tecnativa,'
               'Odoo Community Association (OCA)',
-    'website': 'http://www.serviciosbaeza.com, http://www.antiun.com',
+    'website': 'http://www.tecnativa.com',
     'depends': [
         'event',
     ],
     'data': [
         'views/res_partner_view.xml',
         'views/event_event_view.xml',
+        'views/event_registration_view.xml',
         'wizard/res_partner_register_event_view.xml',
     ],
     "installable": True,

--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -15,7 +15,6 @@ class ResPartner(models.Model):
     event_count = fields.Integer(
         string='Events',
         compute='_compute_event_count',
-        oldname="registration_count",
         help="Count of events with confirmed registrations.",
     )
 

--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -3,7 +3,7 @@
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
 
-from openerp import models, fields, api
+from openerp import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -12,19 +12,18 @@ class ResPartner(models.Model):
     registrations = fields.One2many(
         string="Event registrations",
         comodel_name='event.registration', inverse_name="partner_id")
-    registration_count = fields.Integer(
-        string='Event registrations number', compute='_count_registration')
-    attended_registration_count = fields.Integer(
-        string='Event attended registrations number',
-        compute='_count_attended_registration')
-
-    @api.one
-    @api.depends('registrations')
-    def _count_registration(self):
-        self.registration_count = len(self.registrations)
+    event_count = fields.Integer(
+        string='Events',
+        compute='_compute_event_count',
+        oldname="registration_count",
+        help="Count of events with confirmed registrations.",
+    )
 
     @api.one
     @api.depends('registrations.state')
-    def _count_attended_registration(self):
-        self.attended_registration_count = len(self.registrations.filtered(
-            lambda x: x.state == 'done'))
+    def _compute_event_count(self):
+        self.event_count = len(
+            self.env["event.registration"].search([
+                ("partner_id", "child_of", self.id),
+                ("state", "not in", ("cancel", "draft")),
+            ]).mapped("event_id"))

--- a/partner_event/tests/test_event_registration.py
+++ b/partner_event/tests/test_event_registration.py
@@ -30,15 +30,15 @@ class TestEventRegistration(TransactionCase):
         self.assertEqual(partner_02.email, self.registration_02.email)
         self.assertEqual(partner_02.phone, self.registration_02.phone)
 
-    def test_count_registrations(self):
-        event_1 = self.env.ref('event.event_1')
-        registration_model = self.env['event.registration']
-        registration_03 = registration_model.create({
-            'event_id': event_1.id, 'partner_id': self.partner_01.id})
-        self.assertEqual(self.partner_01.registration_count, 2)
-        self.assertEqual(self.partner_01.attended_registration_count, 0)
-        registration_03.state = 'done'
-        self.assertEqual(self.partner_01.attended_registration_count, 1)
+    def test_count_events(self):
+        event_1 = self.event_0.copy()
+        self.assertEqual(self.partner_01.event_count, 0)
+        self.registration_01.state = "open"
+        self.assertEqual(self.partner_01.event_count, 1)
+        self.registration_02.state = "done"
+        self.registration_02.partner_id = self.partner_01
+        self.registration_02.event_id = event_1
+        self.assertEqual(self.partner_01.event_count, 2)
 
     def test_button_register(self):
         event_1 = self.env.ref('event.event_1')

--- a/partner_event/views/event_registration_view.xml
+++ b/partner_event/views/event_registration_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<openerp>
+<data>
+
+<record id="view_registration_search" model="ir.ui.view">
+    <field name="name">Search attended registrations</field>
+    <field name="model">event.registration</field>
+    <field name="inherit_id" ref="event.view_registration_search"/>
+    <field name="arch" type="xml">
+        <!-- TODO Remove if https://github.com/odoo/odoo/pull/12997 is merged -->
+        <xpath expr="//filter[@domain=&quot;[('state','=','open')]&quot;]"
+               position="attributes">
+            <attribute name="name">open</attribute>
+        </xpath>
+
+        <!-- TODO Change expr if https://github.com/odoo/odoo/pull/12997 is merged -->
+        <xpath expr="//filter[@domain=&quot;[('state','=','open')]&quot;]"
+               position="after">
+            <filter
+                name="done"
+                domain="[('state', '=', 'done')]"
+                string="Attended"/>
+        </xpath>
+    </field>
+</record>
+
+</data>
+</openerp>

--- a/partner_event/views/res_partner_view.xml
+++ b/partner_event/views/res_partner_view.xml
@@ -7,7 +7,8 @@
     <field name="view_type">form</field>
     <field name="name">Registrations</field>
     <field name="view_mode">tree,form,calendar,graph</field>
-    <field name="context">{'search_default_partner_id': active_id, 'default_partner_id': active_id}</field>
+    <field name="domain">[("partner_id", "child_of", active_ids)]</field>
+    <field name="context">{'default_partner_id': active_id, 'search_default_done': 1, 'search_default_open': 1}</field>
 </record>
 
 <record model="ir.ui.view" id="view_partner_form_registrations">
@@ -19,10 +20,10 @@
             <button name="%(partner_event.act_partner_registration)d"
                     type="action"
                     class="oe_stat_button oe_inline"
+                    help="Count of events with confirmed registrations."
                     icon="fa-futbol-o">
-                <field name="registration_count"
-                       widget="statinfo"
-                       string="Events"/>
+                <field name="event_count"
+                       widget="statinfo"/>
             </button>
         </div>
     </field>


### PR DESCRIPTION
Before this patch, "Events" button in the partner form displayed the count of its registrations.

After this patch:
- The button displays the count of events, not of registrations.
- A help tooltip is added to help the user understand that.
- Events where all registrations are cancelled or in draft are not taken into account.
- The resulting registrations view defaults to only those confirmed or attended, but the filter can easily be removed.

Also some unused code has been removed (I checked that no OCA addons use it), and tests are updated to reflect that.

If https://github.com/odoo/odoo/pull/12997 gets merged, this will have some code to change, but nothing should break anyway.

@Tecnativa
