### PR TITLE
[8.0][ADD] website_event_registration_seat_limit module

### DIFF
--- a/website_event_registration_seat_limit/README.rst
+++ b/website_event_registration_seat_limit/README.rst
@@ -1,0 +1,61 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+============================================
+Seats limits in website events registrations
+============================================
+
+This module was written to extend the functionality of events to support
+setting a maximum and a minimum of seats per registration.
+
+Online registration is limited by maximum and minimum number of seats.
+
+Usage
+=====
+
+To use this module, you need to:
+
+* Enter an event form.
+* Use the new fields in the *Registrations* tab.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/186/8.0
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/event/issues>`_. In
+case of trouble, please check there if your issue has already been reported. If
+you spotted it first, help us smashing it by providing a detailed and welcomed
+feedback `here
+<https://github.com/OCA/event/issues/new?body=module:%20website_event_registration_seat_limit%0Aversion:%208.0.4.0.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* `Angel Moya <mailto:am@jamotion.ch>`_.
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/website_event_registration_seat_limit/__init__.py
+++ b/website_event_registration_seat_limit/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# © 2016 Jamotion
+from . import models

--- a/website_event_registration_seat_limit/__openerp__.py
+++ b/website_event_registration_seat_limit/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# © 2016 Jamotion
+
+{
+    "name": "Seats per registration in website events",
+    "version": "8.0.4.0.0",
+    "category": "Tools",
+    "author": "Jamotion, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "http://www.jamotion.ch",
+    "installable": True,
+    "application": False,
+    "summary": "Limit seats per registration",
+    "depends": [
+        "event_registration_seat_limit",
+        "website_event_sale"
+    ],
+    "data": [
+        "views/event_template.xml",
+    ],
+}

--- a/website_event_registration_seat_limit/models/__init__.py
+++ b/website_event_registration_seat_limit/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# © 2016 Jamotion
+from . import event

--- a/website_event_registration_seat_limit/models/event.py
+++ b/website_event_registration_seat_limit/models/event.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # © 2016 Jamotion
 
-from openerp import models, api, fields, _
+from openerp import models, api
 
 
 class EventEventTicket(models.Model):

--- a/website_event_registration_seat_limit/models/event.py
+++ b/website_event_registration_seat_limit/models/event.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# © 2016 Jamotion
+
+from openerp import models, api, fields, _
+
+
+class EventEventTicket(models.Model):
+    _inherit = 'event.event.ticket'
+
+    @api.multi
+    def get_seats_range(self):
+        self.ensure_one()
+        min_seats = self.event_id.registration_seats_min
+        max_seats = min(min(
+            self.event_id.registration_seats_max or 9,
+            self.seats_available or 9) + 1, 10)
+        return range(min_seats, max_seats)

--- a/website_event_registration_seat_limit/views/event_template.xml
+++ b/website_event_registration_seat_limit/views/event_template.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<openerp>
+    <data>
+
+        <template id="event_description_full" inherit_id="website_event_sale.event_description_full" name="Event's Ticket limit">
+            <xpath expr="//select[@class='form-control']" position="replace">
+                <select t-if="ticket.seats_available or not ticket.seats_max" t-attf-name="ticket-#{ ticket.id }" class="form-control">
+                    <t t-foreach="ticket.get_seats_range()" t-as="nb"><option t-esc="nb"/></t>
+                </select>
+            </xpath>
+        </template>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Add module that extend event_registration_seat_limit https://github.com/OCA/event/tree/8.0/event_registration_seat_limit to limit the quantity selector on online register process

From: https://github.com/OCA/website/pull/253
