### PR TITLE
[FIX][website_event_excerpt_img] Use event's timezone.

### DIFF
--- a/website_event_excerpt_img/__openerp__.py
+++ b/website_event_excerpt_img/__openerp__.py
@@ -4,7 +4,7 @@
 {
     "name": "Excerpt + Image in Events",
     "summary": "New layout for event summary, including an excerpt and image",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.0.1",
     "category": "Website",
     "website": "https://www.tecnativa.com",
     "author": "Antiun Ingeniería S.L., Tecnativa, "

--- a/website_event_excerpt_img/__openerp__.py
+++ b/website_event_excerpt_img/__openerp__.py
@@ -4,7 +4,7 @@
 {
     "name": "Excerpt + Image in Events",
     "summary": "New layout for event summary, including an excerpt and image",
-    "version": "8.0.1.0.1",
+    "version": "8.0.1.1.0",
     "category": "Website",
     "website": "https://www.tecnativa.com",
     "author": "Antiun Ingeniería S.L., Tecnativa, "

--- a/website_event_excerpt_img/views/event.xml
+++ b/website_event_excerpt_img/views/event.xml
@@ -54,12 +54,12 @@
                         <i class="fa fa-clock-o"/>
                         <span
                             itemprop="startDate"
-                            t-field="event.date_begin"
+                            t-field="event.with_context(tz=event.date_tz).date_begin"
                             t-field-options='{"hide_seconds":"True"}'/>
                         <i>to</i>
                         <span
                             itemprop="endDate"
-                            t-field="event.date_end"
+                            t-field="event.with_context(tz=event.date_tz).date_end"
                             t-field-options='{"hide_seconds":"True"}'/>
                     </div>
                     <div


### PR DESCRIPTION
Without this patch, the event's start and end dates (and times) will be inaccurate.

@Tecnativa.
