### PR TITLE
[10.0][FIX] event_project: project name

### DIFF
--- a/event_project/__manifest__.py
+++ b/event_project/__manifest__.py
@@ -7,7 +7,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Event project",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": "Tecnativa, "
               "Odoo Community Association (OCA)",
     "website": "https://www.tecnativa.com",

--- a/event_project/models/event_event.py
+++ b/event_project/models/event_event.py
@@ -37,7 +37,7 @@ class EventEvent(models.Model):
         if self.project_id:
             project_vals = {}
             if vals.get('name'):
-                project_vals['name'] = self.name
+                project_vals['name'] = self.display_name
             if vals.get('date_begin'):
                 project_vals['date'] = self.date_begin
                 recalculate = True
@@ -45,7 +45,7 @@ class EventEvent(models.Model):
                 project_vals['event_id'] = self.id
                 project_vals['calculation_type'] = 'date_end'
                 project_vals['date'] = self.date_begin
-                project_vals['name'] = self.name
+                project_vals['name'] = self.display_name
                 recalculate = True
             if project_vals:
                 self.project_id.write(project_vals)

--- a/event_project/tests/test_event_project.py
+++ b/event_project/tests/test_event_project.py
@@ -40,7 +40,7 @@ class TestEventProject(common.SavepointCase):
         self.assertEqual(self.event.project_id.calculation_type, 'date_end')
         self.assertEqual(self.event.project_id.date,
                          str.split(self.event.date_begin, ' ')[0])
-        self.assertEqual(self.event.name, self.event.project_id.name)
+        self.assertEqual(self.event.display_name, self.event.project_id.name)
 
     def test_02_project_recalculation(self):
         self.event.date_begin = self.date['begin2']
@@ -48,7 +48,7 @@ class TestEventProject(common.SavepointCase):
         self.event.name = 'Event name changed'
         self.assertEqual(self.event.project_id.date,
                          str.split(self.event.date_begin, ' ')[0])
-        self.assertEqual(self.event.name, self.event.project_id.name)
+        self.assertEqual(self.event.display_name, self.event.project_id.name)
 
     def test_03_project_change(self):
         self.event.project_id = self.project_2
@@ -58,7 +58,7 @@ class TestEventProject(common.SavepointCase):
         self.assertEqual(self.event.project_id.calculation_type, 'date_end')
         self.assertEqual(self.event.project_id.date,
                          str.split(self.event.date_begin, ' ')[0])
-        self.assertEqual(self.event.name, self.event.project_id.name)
+        self.assertEqual(self.event.display_name, self.event.project_id.name)
         self.assertEqual(self.event.count_tasks, 1)
 
     def test_04_cancel_and_draft_event(self):


### PR DESCRIPTION
- Projects generated by events were missing dates in their names.

cc @Tecnativa