### PR TITLE
[IMP] partner_event: forbid partner deletion if it has event registrations

### DIFF
--- a/partner_event/README.rst
+++ b/partner_event/README.rst
@@ -16,6 +16,7 @@ It also includes:
 * Partner column is visible on registration one2many list inside the event.
 * Action in partner tree view 'More' button, to register several partners
   to an event
+* Restricts partner deletion when event attendees are linked to it.
 
 Configuration
 =============

--- a/partner_event/models/event_registration.py
+++ b/partner_event/models/event_registration.py
@@ -11,6 +11,9 @@ from odoo import api, fields, models
 class EventRegistration(models.Model):
     _inherit = "event.registration"
 
+    partner_id = fields.Many2one(
+        ondelete='restrict',
+    )
     attendee_partner_id = fields.Many2one(
         comodel_name='res.partner',
         string='Attendee Partner',


### PR DESCRIPTION
- If the partner has event registrations it won't be allowed to delete it.

cc @Tecnativa