### PR TITLE
[9.0][ADD] crm_event_registration_partner_unique

### DIFF
--- a/crm_event_registration_partner_unique/README.rst
+++ b/crm_event_registration_partner_unique/README.rst
@@ -1,0 +1,53 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+================================
+CRM and Unique Partner per Event
+================================
+
+This module prevents duplicated partners in an event with *Forbid duplicates*
+enabled when partners in that event are merged.
+
+Autoinstalls when `crm` is installed along with
+`event_registration_partner_unique`.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/199/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/event/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* David Vidal <david.vidal@tecnativa.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/crm_event_registration_partner_unique/__init__.py
+++ b/crm_event_registration_partner_unique/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import wizards

--- a/crm_event_registration_partner_unique/__openerp__.py
+++ b/crm_event_registration_partner_unique/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Unique Partner per Event and CRM",
+    "summary": "Avoids duplicates in events when partners are merged",
+    "version": "9.0.1.0.0",
+    "category": "Events",
+    "website": "http://github.com/OCA/event",
+    "author": "Tecnativa, "
+              "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "depends": [
+        "event_registration_partner_unique",
+        "crm",
+    ],
+    "data": [
+    ],
+}

--- a/crm_event_registration_partner_unique/i18n/es.po
+++ b/crm_event_registration_partner_unique/i18n/es.po
@@ -1,0 +1,26 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* crm_event_registration_partner_unique
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-02-19 18:23+0000\n"
+"PO-Revision-Date: 2018-02-19 18:23+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: crm_event_registration_partner_unique
+#: code:addons/crm_event_registration_partner_unique/wizards/partner_merge.py:31
+#, python-format
+msgid "These action would produce duplicated partners in an event wich has it forbidden.\n"
+"Event ID: %d\n"
+"Name: %s"
+msgstr "Esta acción duplicaría contactos en un evento que lo tiene prohibido.\n"
+"ID del evento: %i\n"
+"Nombre: %s"

--- a/crm_event_registration_partner_unique/tests/__init__.py
+++ b/crm_event_registration_partner_unique/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_crm_deduplicate_event_unique

--- a/crm_event_registration_partner_unique/tests/test_crm_deduplicate_event_unique.py
+++ b/crm_event_registration_partner_unique/tests/test_crm_deduplicate_event_unique.py
@@ -5,6 +5,7 @@
 from openerp.tests import common
 from openerp.exceptions import UserError
 
+
 class TestDeduplicateEventUnique(common.TransactionCase):
     def setUp(self):
         super(TestDeduplicateEventUnique, self).setUp()

--- a/crm_event_registration_partner_unique/tests/test_crm_deduplicate_event_unique.py
+++ b/crm_event_registration_partner_unique/tests/test_crm_deduplicate_event_unique.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests import common
+from openerp.exceptions import UserError
+
+class TestDeduplicateEventUnique(common.TransactionCase):
+    def setUp(self):
+        super(TestDeduplicateEventUnique, self).setUp()
+        self.partner_1 = self.env['res.partner'].create({
+            'name': 'Partner 1',
+        })
+        self.partner_2 = self.env['res.partner'].create({
+            'name': 'Partner 2',
+        })
+        self.event = self.env['event.event'].create({
+            'name': 'Test event',
+            'date_begin': '2018-01-11 15:20:00',
+            'date_end': '2018-01-11 22:00:00',
+            'seats_availability': 'unlimited',
+        })
+        self.registration_1 = self.env["event.registration"].create({
+            "event_id": self.event.id,
+            "partner_id": self.partner_1.id,
+        })
+        self.registration_2 = self.env["event.registration"].create({
+            "event_id": self.event.id,
+            "partner_id": self.partner_2.id,
+        })
+        self.wizard = self.env['base.partner.merge.automatic.wizard'].create({
+            'dst_partner_id': self.partner_1.id,
+            'partner_ids': [(4, self.partner_1.id), (4, self.partner_2.id)],
+            'group_by_name': True,
+        })
+
+    def test_01_merge_forbidden_event(self):
+        self.event.forbid_duplicates = True
+        with self.assertRaises(UserError):
+            self.wizard.merge_cb()
+
+    def test_02_merge_allowed_event(self):
+        self.wizard.merge_cb()
+        self.assertEqual(self.event.registration_ids.mapped('partner_id').id,
+                         self.partner_1.id)

--- a/crm_event_registration_partner_unique/wizards/__init__.py
+++ b/crm_event_registration_partner_unique/wizards/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import partner_merge

--- a/crm_event_registration_partner_unique/wizards/partner_merge.py
+++ b/crm_event_registration_partner_unique/wizards/partner_merge.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import _, models
+from openerp.exceptions import UserError
+
+
+class BasePartnerMergeAutomaticWizard(models.TransientModel):
+    _inherit = "base.partner.merge.automatic.wizard"
+
+    def _update_foreign_keys(self, cr, uid,
+                             src_partners, dst_partner, context=None):
+        self.get_fk_on(cr, 'res_partner')
+        for table, column in cr.fetchall():
+            partners = (map(int, src_partners))
+            partners.append(dst_partner.id)
+            if table == 'event_registration':
+                query = """ SELECT r.event_id, e.name, count(r.partner_id)
+                            FROM event_registration r
+                            LEFT JOIN event_event e on r.event_id = e.id
+                            WHERE e.forbid_duplicates
+                            AND r.partner_id IN %s
+                            GROUP BY r.event_id, e.name
+                            """
+                cr.execute(query, (tuple(partners),))
+                for event_id, name, count_partner in cr.fetchall():
+                    if count_partner > 1:
+                        raise UserError(
+                            _("These action would produce duplicated partners "
+                              "in an event wich has it forbidden.\n"
+                              "Event ID: %d\n"
+                              "Name: %s") % (event_id, name))
+        return super(
+            BasePartnerMergeAutomaticWizard, self)._update_foreign_keys(
+            cr, uid, src_partners, dst_partner, context)


### PR DESCRIPTION
This module prevents duplicated partners in an event with *Forbid duplicates* enabled when partners in that event are merged.

Autoinstalls when `crm` is installed along with `event_registration_partner_unique`.

cc @Tecnativa
