### PR TITLE
[FIX] partner_event: Respect attendee language

### DIFF
--- a/partner_event/__init__.py
+++ b/partner_event/__init__.py
@@ -2,3 +2,4 @@
 
 from . import models
 from . import wizard
+from .hooks import post_init_hook, uninstall_hook

--- a/partner_event/__manifest__.py
+++ b/partner_event/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Link partner to events',
-    'version': '10.0.2.0.1',
+    'version': '10.0.2.1.0',
     'category': 'Marketing',
     'author': 'Tecnativa,'
               'Odoo Community Association (OCA)',
@@ -17,6 +17,8 @@
     'depends': [
         'event',
     ],
+    "post_init_hook": "post_init_hook",
+    "uninstall_hook": "uninstall_hook",
     'data': [
         'views/res_partner_view.xml',
         'views/event_event_view.xml',

--- a/partner_event/hooks.py
+++ b/partner_event/hooks.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, SUPERUSER_ID
+
+LANG_OLD = "${object.partner_id.lang}"
+LANG_NEW = "${object.attendee_partner_id.lang or object.partner_id.lang}"
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    # Fix computing of lang for affected templates
+    tpls = env["mail.template"].search([
+        ("model_id", "=", "event.registration"),
+        ("lang", "=", LANG_OLD),
+    ])
+    tpls.write({
+        "lang": LANG_NEW,
+    })
+
+
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    # Restore computing of lang for affected templates
+    tpls = env["mail.template"].search([
+        ("model_id", "=", "event.registration"),
+        ("lang", "=", LANG_NEW),
+    ])
+    tpls.write({
+        "lang": LANG_OLD,
+    })

--- a/partner_event/migrations/10.0.2.1.0/post-migrate.py
+++ b/partner_event/migrations/10.0.2.1.0/post-migrate.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.partner_event import post_init_hook
+
+
+def migrate(cr, version):
+    post_init_hook(cr, None)


### PR DESCRIPTION
- When attendees were registered from the website and the event was configured to create a partner, the partner did not have the user's language.
- When printing the registration badge, it was printed in linked billing partner or current user's language. Now it is printed in the attendee language if available.
- When writing in the chatter, attendee partner is suggested as follower.

@Tecnativa