### PR TITLE
[FIX] website_event_filter_selector: Sane events order

### DIFF
--- a/website_event_filter_selector/__openerp__.py
+++ b/website_event_filter_selector/__openerp__.py
@@ -4,7 +4,7 @@
 {
     "name": "Website Event Selection Filters",
     "summary": "Add a customizable top area to filter events with selectors",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "category": "Website",
     "website": "https://www.tecnativa.com",
     "author": "Antiun Ingeniería S.L., "

--- a/website_event_filter_selector/__openerp__.py
+++ b/website_event_filter_selector/__openerp__.py
@@ -6,9 +6,8 @@
     "summary": "Add a customizable top area to filter events with selectors",
     "version": "9.0.1.0.1",
     "category": "Website",
-    "website": "https://www.tecnativa.com",
-    "author": "Antiun Ingeniería S.L., "
-              "Tecnativa, "
+    "website": "https://github.com/OCA/event",
+    "author": "Tecnativa, "
               "Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "application": False,

--- a/website_event_filter_selector/controllers/main.py
+++ b/website_event_filter_selector/controllers/main.py
@@ -68,7 +68,7 @@ class WebsiteEvent(website_event):
             scope=5)
 
         # Return new event results
-        order = 'website_published desc, date_begin'
+        order = 'date_begin'
         if searches["date"] == "old":
             order += " desc"
         values["event_ids"] = event_obj.search(


### PR DESCRIPTION
Order events by date, no matter if they are published or not.

It implements the same logic as done in https://github.com/odoo/odoo/pull/23597 in this addon.

@Tecnativa