### PR TITLE
[FIX] event_registration_mass_mailing: Fix integration tests

### DIFF
--- a/event_registration_mass_mailing/__manifest__.py
+++ b/event_registration_mass_mailing/__manifest__.py
@@ -6,7 +6,7 @@
 {
     'name': "Mass mailing from events",
     'category': 'Marketing',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'depends': [
         'event',
         'mass_mailing'

--- a/event_registration_mass_mailing/tests/test_event_registration_mail_list_wizard.py
+++ b/event_registration_mass_mailing/tests/test_event_registration_mail_list_wizard.py
@@ -2,9 +2,11 @@
 # Copyright 2016 Antiun Ingenieria S.L. - Javier Iniesta
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import at_install, post_install, TransactionCase
 
 
+@at_install(False)
+@post_install(True)
 class TestEventRegistrationMailListWizard(TransactionCase):
 
     def setUp(self):


### PR DESCRIPTION
Testing after installing mass_mailing_list_dynamic produces:

    IntegrityError: null value in column "sync_domain" violates not-null constraint

@Tecnativa