### PR TITLE
[FIX] website_event_snippet_calendar: Display event timezone

### DIFF
--- a/website_event_snippet_calendar/README.rst
+++ b/website_event_snippet_calendar/README.rst
@@ -32,6 +32,11 @@ Known issues / Roadmap
 ======================
 
 * Remove ``bootstrap-datetimepicker`` bundled library when migrating to v11.
+* Do not rely on ``date_begin_located`` field in v11+, because implementation
+  has changed, and it returns a human-readable format instead of a
+  machine-parseable one.
+* This addon is affected by https://github.com/odoo/odoo/issues/27179 like
+  Odoo itself. It should get the same fix as upstream when it lands.
 
 Bug Tracker
 ===========

--- a/website_event_snippet_calendar/__manifest__.py
+++ b/website_event_snippet_calendar/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Event Calendar and List Snippet and Iframe",
     "summary": "Browsable calendar with events list for your website",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Website",
     "website": "https://github.com/OCA/event",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/website_event_snippet_calendar/controllers/main.py
+++ b/website_event_snippet_calendar/controllers/main.py
@@ -58,7 +58,8 @@ class EventCalendar(Controller):
             domain=domain,
             limit=limit,
             fields=[
-                "date_begin",
+                # TODO Use a v10-like field in v11+
+                "date_begin_located",
                 "name",
                 "event_type_id",
                 "website_published",

--- a/website_event_snippet_calendar/static/src/js/animation.js
+++ b/website_event_snippet_calendar/static/src/js/animation.js
@@ -155,7 +155,7 @@ odoo.define('website_event_snippet_calendar.animation', function (require) {
         },
         _render_list: function (events) {
             _.each(events, function (element) {
-                element.date_begin = moment(element.date_begin)
+                element.date_begin = moment(element.date_begin_located)
                     .format(this.date_format);
             }, this);
             this.$list.html(core.qweb.render(


### PR DESCRIPTION
Before this patch, the user was getting the Public User's TZ on the
calendar view.

After merged, only the event's timzeone will be used to display dates.

It is, however, affected by https://github.com/odoo/odoo/issues/27179,
which means that there is a possible mismatch between the date used
to search and the one used to display, most likely to be hit when
events have very different timzeones. Added to Known Issues.

@Tecnativa