### PR TITLE
Use logged-in users name and email in event registration automatically

### DIFF
--- a/website_event_require_login/__manifest__.py
+++ b/website_event_require_login/__manifest__.py
@@ -13,7 +13,7 @@
     'data': [
         'views/event_views.xml',
         'views/website_event_templates.xml',
-		'views/website_event_registration_attendee_details_views.xml'
+        'views/website_event_registration_attendee_details_views.xml'
     ],
     'installable': True,
     'license': 'AGPL-3',

--- a/website_event_require_login/__manifest__.py
+++ b/website_event_require_login/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Website Event Require Login',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'author': 'Tecnativa, '
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/event',
@@ -13,6 +13,7 @@
     'data': [
         'views/event_views.xml',
         'views/website_event_templates.xml',
+		'views/website_event_registration_attendee_details_views.xml'
     ],
     'installable': True,
     'license': 'AGPL-3',

--- a/website_event_require_login/readme/CONTRIBUTORS.rst
+++ b/website_event_require_login/readme/CONTRIBUTORS.rst
@@ -2,3 +2,5 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
   * David Vidal
   * Rafael Blasco
+
+* Chris Mann

--- a/website_event_require_login/views/website_event_registration_attendee_details_views.xml
+++ b/website_event_require_login/views/website_event_registration_attendee_details_views.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="registration_attendee_details" model="ir.ui.view">
+        <field name="inherit_id" ref="website_event.registration_attendee_details"/>
+        <field name="arch" type="xml">
+          <xpath expr="//*[hasclass('container')]/t[3]" position="replace">
+            <t t-foreach="tickets" t-as="ticket">
+              <h4 class="o_page_header mt16">
+                <strong>
+                  Ticket Type #<t t-raw="counter_type"/>: <t t-esc="ticket['name']"/>
+                  <t t-if="ticket['price'] == 0">(Free)</t>
+                </strong>
+              </h4>
+              <div class="row">
+                <div class="col-lg-4">
+                  <strong>Name</strong>
+                </div>
+                <div class="col-lg-5">
+                  <strong>Email</strong>
+                </div>
+                <div class="col-lg-3" t-if="request.env.user == request.website.user_id">
+                  <strong>Phone</strong>
+                  <span class="text-muted">(Optional)</span>
+                </div>
+              </div>
+              <t t-foreach="range(1, ticket['quantity'] + 1)" t-as="att_counter" name="attendee_loop">
+                <t t-set="counter" t-value="counter + 1"/>
+                <div class="row mb4">
+                  <t t-set="attendee_placeholder">Attendee #%s</t>
+                  <t t-if="request.env.user == request.website.user_id">
+                    <div class="col-lg-4">
+                      <input class="form-control" type="text" t-attf-name="#{counter}-name" required="This field is required" t-att-placeholder="attendee_placeholder %counter"/>
+                    </div>
+                    <div class="col-lg-5">
+                      <input class="form-control" type="email" t-attf-name="#{counter}-email" required="This field is required"/>
+                    </div>
+                    <div class="col-lg-3">
+                      <input class="form-control" type="tel" t-attf-name="#{counter}-phone"/>
+                    </div>
+                  </t>
+                  <t t-else="">
+                    <div class="col-lg-4">
+                      <input t-attf-value="#{user_id.name}" readonly="1" class="form-control" type="text" t-attf-name="#{counter}-name" required="This field is required" t-att-placeholder="attendee_placeholder %counter"/>
+                    </div>
+                    <div class="col-lg-5">
+                      <input t-attf-value="#{user_id.email}" readonly="1" class="form-control" type="email" t-attf-name="#{counter}-email" required="This field is required"/>
+                    </div>
+                  </t>
+                  <input class="d-none" type="text" t-attf-name="#{counter}-ticket_id" t-attf-value="#{ticket['id']}"/>
+                </div>
+              </t>
+              <t t-set="counter_type" t-value="counter_type + 1"/>
+            </t>
+          </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/website_event_require_login/views/website_event_registration_attendee_details_views.xml
+++ b/website_event_require_login/views/website_event_registration_attendee_details_views.xml
@@ -3,6 +3,7 @@
 
     <record id="registration_attendee_details" model="ir.ui.view">
         <field name="inherit_id" ref="website_event.registration_attendee_details"/>
+        <field name="priority">99</field>
         <field name="arch" type="xml">
           <xpath expr="//*[hasclass('container')]/t[3]" position="replace">
             <t t-foreach="tickets" t-as="ticket">


### PR DESCRIPTION
Update the website_event_registration_attendee_details view to use the logged in user's name and email address instead of allowing freetyped input fields to prevent human error.

Combined with requiring a login for an event, helps simplify registering process as users shouldn't need to re-enter their details. Phone is hidden also as not needed if they are linked to a partner record.