### PR TITLE
[11.0] [FIX] Replace deprecated way to set default.

### DIFF
--- a/event_session/models/res_config_settings.py
+++ b/event_session/models/res_config_settings.py
@@ -13,7 +13,8 @@ class ResConfigSettings(models.TransientModel):
     )
 
     @api.multi
-    def set_default_event_mail_template_id(self):
+    def set_values(self):
+        super().set_values()
         self.env['ir.default'].set(
             'res.config.settings', 'event_mail_template_id',
             self.event_mail_template_id.id


### PR DESCRIPTION
Prevent this message:
    odoo.addons.base.res.res_config:552 execute Methods that start with  `set_` are deprecated. Override `set_values` instead (Method set_default_event_mail_template_id)