### PR TITLE
[IMP] partner_event: add data to old registrations

### DIFF
--- a/partner_event/__init__.py
+++ b/partner_event/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizard
+from .hooks import post_init_hook

--- a/partner_event/__manifest__.py
+++ b/partner_event/__manifest__.py
@@ -24,5 +24,6 @@
         'views/event_registration_view.xml',
         'wizard/res_partner_register_event_view.xml',
     ],
+    'post_init_hook': 'post_init_hook',
     "installable": True,
 }

--- a/partner_event/hooks.py
+++ b/partner_event/hooks.py
@@ -1,0 +1,22 @@
+# Copyright 2019 David Vidal
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+from odoo import api, SUPERUSER_ID
+
+
+def post_init_hook(cr, registry):
+    """Preload proper attendee partner for existing registrations using
+       the same rules the module does"""
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        attendees_emails = env['event.registration'].read_group([
+            ('email', '!=', False),
+            ], ['email'], groupby='email')
+        for email in attendees_emails:
+            attendee_partner = env['res.partner'].search([
+                ('email', '=ilike', email['email'])
+            ], limit=1)
+            if attendee_partner:
+                attendees = env['event.registration'].search(email['__domain'])
+                attendees.write({
+                    'attendee_partner_id': attendee_partner.id,
+                })


### PR DESCRIPTION
When installing the module, old registrations attendee partner should be set in the same way the new ones do.

cc @Tecnativa