### PR TITLE
[FIX] website_event_snippet_calendar: Respect user lang

### DIFF
--- a/website_event_snippet_calendar/controllers/main.py
+++ b/website_event_snippet_calendar/controllers/main.py
@@ -9,7 +9,7 @@ from openerp.http import Controller, request, route
 
 class EventCalendar(Controller):
     @route("/website_event_snippet_calendar/days_with_events",
-           auth="public", type="json")
+           auth="public", type="json", website=True)
     def days_with_events(self, start, end):
         """Let visitors know when are there going to be any events.
 
@@ -37,7 +37,7 @@ class EventCalendar(Controller):
         return [Date.to_string(day) for day in days]
 
     @route("/website_event_snippet_calendar/events_for_day",
-           auth="public", type="json")
+           auth="public", type="json", website=True)
     def events_for_day(self, day=None, limit=None):
         """List events for a given day.
 


### PR DESCRIPTION
These controllers were ignoring the `website_lang` cookie because they were not enabled for website. Thus, event results were downloaded in default language instead of the current one.

@Tecnativa TT20711