### PR TITLE
[MOD] 12.0 Replace code using system lang by babel dates translations

### DIFF
--- a/event_session/__manifest__.py
+++ b/event_session/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Event Sessions',
-    'version': '12.0.1.0.1',
+    'version': '12.0.1.0.2',
     'author': 'Tecnativa, '
               'Odoo Community Association (OCA)',
     "license": "AGPL-3",


### PR DESCRIPTION
The big issue with this kind of code is that if you have a user with a
certain locale being used, it will override the locale system wide and
the next request on the server may have the dates formatted with
strftime in a different language than expected...

The other issue is that some systems do not provide a set of actual
locales so on a server running in docker without manually modifying
a dockerfile to install a set of locales, it may fail to switch
the locale to a non existing one. It will just fail to compute the field.

Babel is already a dependency of odoo and it's a bit strange to not use it.

This probably can be ported to other versions of event repository.