### PR TITLE
[FIX] website_event_snippet_calendar: BS4 styles

### DIFF
--- a/website_event_snippet_calendar/static/src/xml/snippets.xml
+++ b/website_event_snippet_calendar/static/src/xml/snippets.xml
@@ -6,7 +6,7 @@
     <t t-name="website_event_snippet_calendar.list">
         <t t-foreach="events" t-as="event">
             <div class="row">
-                <div class="col-md-12 event_details">
+                <div class="col-12 event_details">
                     <span class="date">
                         <t t-esc="event.date_begin"/>
                     </span>
@@ -14,12 +14,12 @@
                         <t t-esc="event.event_type_id[1]"/>
                     </span>
                 </div>
-                <div class="col-md-12 event_title">
+                <div class="col-12 event_title">
                     <a t-att-href="event.website_url" target="_top">
                         <h3 class="mt0">
                             <t t-esc="event.name"/>
                             <t t-if="!event.website_published">
-                                <span class="label label-danger">unpublished</span>
+                                <span class="badge badge-danger">unpublished</span>
                             </t>
                         </h3>
                     </a>


### PR DESCRIPTION
Pretty obvious things missing from BS4 migration.

@Tecnativa TT17632