### PR TITLE
[13.0] Create module website_event_sale_single_attendee

### DIFF
--- a/website_event_sale_single_attendee/__init__.py
+++ b/website_event_sale_single_attendee/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/website_event_sale_single_attendee/__manifest__.py
+++ b/website_event_sale_single_attendee/__manifest__.py
@@ -17,5 +17,6 @@
     "data": [
         "templates/event_templates.xml",
         "views/event_event.xml",
+        "views/event_type.xml",
     ],
 }

--- a/website_event_sale_single_attendee/__manifest__.py
+++ b/website_event_sale_single_attendee/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Website Event Sale Single Attendee",
+    "summary": "Register a single attendee for multiple tickets",
+    "version": "12.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Website/Website",
+    "website": "https://github.com/OCA/event",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "website_event_sale",
+    ],
+    "data": [
+        "templates/event_templates.xml",
+        "views/event_event.xml",
+    ],
+}

--- a/website_event_sale_single_attendee/controllers/__init__.py
+++ b/website_event_sale_single_attendee/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/website_event_sale_single_attendee/controllers/main.py
+++ b/website_event_sale_single_attendee/controllers/main.py
@@ -1,0 +1,53 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import http
+from odoo.addons.website_event_sale.controllers.main import WebsiteEventSaleController
+from odoo.http import request
+
+
+class WebsiteEventSaleControllerSingleAttendee(WebsiteEventSaleController):
+
+    def _process_registration_details(self, details):
+        """Multiply single attendee registration according to ticket qties"""
+        registrations = super()._process_registration_details(details)
+        if len(registrations) == 1 and "ticket_id" not in registrations[0]:
+            # Get the quantities for each ticket_id
+            registration_details = {}
+            ticket_ids_quantities = {}
+            for key, value in registrations[0].items():
+                if key.startswith("ticket_id_qty-"):
+                    ticket_id = key.split("-", 1)[1]
+                    ticket_ids_quantities[ticket_id] = value
+                else:
+                    registration_details[key] = value
+            # Multiply registration details for each ticket according to the
+            # quantities
+            if ticket_ids_quantities:
+                registrations = []
+                for ticket_id, qty in ticket_ids_quantities.items():
+                    for cnt in range(0, int(qty)):
+                        reg = registration_details.copy()
+                        reg["ticket_id"] = ticket_id
+                        registrations.append(reg)
+        return registrations
+
+    @http.route(['/event/<model("event.event"):event>/registration/new'],
+                type='json', auth="public", methods=['POST'], website=True)
+    def registration_new(self, event, **post):
+        if not event.single_attendee_registration:
+            return super().registration_new(event, **post)
+        # Reimplementation of super method with change of rendered template
+        tickets = self._process_tickets_details(post)
+        availability_check = True
+        if event.seats_availability == 'limited':
+            ordered_seats = 0
+            for ticket in tickets:
+                ordered_seats += ticket['quantity']
+            if event.seats_available < ordered_seats:
+                availability_check = False
+        if not tickets:
+            return False
+        return request.env['ir.ui.view'].render_template(
+            "website_event_sale_single_attendee.registration_attendee_details_single",
+            {'tickets': tickets, 'event': event, 'availability_check': availability_check}
+        )

--- a/website_event_sale_single_attendee/models/__init__.py
+++ b/website_event_sale_single_attendee/models/__init__.py
@@ -1,0 +1,1 @@
+from . import event

--- a/website_event_sale_single_attendee/models/__init__.py
+++ b/website_event_sale_single_attendee/models/__init__.py
@@ -1,1 +1,2 @@
 from . import event
+from . import event_type

--- a/website_event_sale_single_attendee/models/event.py
+++ b/website_event_sale_single_attendee/models/event.py
@@ -1,0 +1,12 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class EventEvent(models.Model):
+
+    _inherit = "event.event"
+
+    single_attendee_registration = fields.Boolean(
+        help="Check this box to ask for a single attendee at registration"
+    )

--- a/website_event_sale_single_attendee/models/event.py
+++ b/website_event_sale_single_attendee/models/event.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class EventEvent(models.Model):
@@ -10,3 +10,10 @@ class EventEvent(models.Model):
     single_attendee_registration = fields.Boolean(
         help="Check this box to ask for a single attendee at registration"
     )
+
+    @api.onchange('event_type_id')
+    def _onchange_type(self):
+        res = super()._onchange_type()
+        if self.event_type_id and self.event_type_id.single_attendee_registration:
+            self.single_attendee_registration = self.event_type_id.single_attendee_registration
+        return res

--- a/website_event_sale_single_attendee/models/event_type.py
+++ b/website_event_sale_single_attendee/models/event_type.py
@@ -1,0 +1,12 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class EventType(models.Model):
+
+    _inherit = 'event.type'
+
+    single_attendee_registration = fields.Boolean(
+        help="Ask for a single attendee at registration on the website"
+    )

--- a/website_event_sale_single_attendee/readme/CONTRIBUTORS.rst
+++ b/website_event_sale_single_attendee/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/website_event_sale_single_attendee/readme/DESCRIPTION.rst
+++ b/website_event_sale_single_attendee/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module allows to define an event with 'Single Attendee Registration' so
+that when a user registers on the website, he will not have to enter a name and
+an email for each ticket, but only one name and one email, that will be used
+as attendee for every ticket purchased.

--- a/website_event_sale_single_attendee/readme/ROADMAP.rst
+++ b/website_event_sale_single_attendee/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+* This module breaks the feature of website_event_questions, and a glue module
+  must restrict the checkbox 'Ask each attendee' (`event.question.is_individual`)
+  to False, if the event is set with 'Single Attendee Registration'.

--- a/website_event_sale_single_attendee/readme/ROADMAP.rst
+++ b/website_event_sale_single_attendee/readme/ROADMAP.rst
@@ -1,3 +1,4 @@
 * This module breaks the feature of website_event_questions, and a glue module
   must restrict the checkbox 'Ask each attendee' (`event.question.is_individual`)
   to False, if the event is set with 'Single Attendee Registration'.
+* As only one e-mail is registered, the attendee will receive as many e-mails as tickets he ordered.

--- a/website_event_sale_single_attendee/templates/event_templates.xml
+++ b/website_event_sale_single_attendee/templates/event_templates.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="registration_attendee_details_single" name="Registration Attendee Details">
+        <div id="modal_attendees_registration" class="modal fade" tabindex="-1" role="dialog">
+            <div class="modal-dialog modal-lg" role="document">
+                <form id="attendee_registration" t-attf-action="/event/#{slug(event)}/registration/confirm" method="post" class="js_website_submit_form">
+                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                    <div class="modal-content">
+                        <div class="modal-header align-items-center">
+                            <h4 class="modal-title">Attendees</h4>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span>&amp;times;</span></button>
+                        </div>
+                        <t t-if="availability_check">
+                            <div class="modal-body bg-light border-bottom">
+                                <h5 class="mt-1 pb-2 border-bottom">Tickets holder</h5>
+
+                                <t t-foreach="tickets" t-as="ticket">
+                                    <div class="row col-lg"><span t-esc="ticket['quantity']" />x - <span t-esc="ticket['name']"/></div>
+                                    <input class="d-none" type="text" t-attf-name="0-ticket_id_qty-#{ticket['id']}" t-attf-value="#{ticket['quantity']}"/>
+                                </t>
+                                <div class="row">
+                                    <div class="col-lg my-2">
+                                        <label>Name</label>
+                                        <input class="form-control" type="text" t-attf-name="1-name" required="This field is required"/>
+                                    </div>
+                                    <div class="col-lg my-2">
+                                        <label>Email</label>
+                                        <input class="form-control" type="email" t-attf-name="1-email" required="This field is required"/>
+                                    </div>
+                                    <div class="col-lg my-2">
+                                        <label>Phone <small>(Optional)</small></label>
+                                        <input class="form-control" type="tel" t-attf-name="1-phone"/>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </t>
+                        <t t-if="not availability_check">
+                            <strong> You ordered more tickets than available seats</strong>
+                        </t>
+                        <div class="modal-footer border-0 justify-content-between">
+                            <button type="button" class="btn btn-secondary js_goto_event" data-dismiss="modal">Cancel</button>
+                            <button type="submit" class="btn btn-primary" t-if="availability_check">Continue</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </template>
+</odoo>

--- a/website_event_sale_single_attendee/views/event_event.xml
+++ b/website_event_sale_single_attendee/views/event_event.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="view_event_form_inherit">
+        <field name="name">event.event.form</field>
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_form" />
+        <field name="arch" type="xml">
+            <field name="auto_confirm" position="after">
+                <field name="single_attendee_registration" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/website_event_sale_single_attendee/views/event_type.xml
+++ b/website_event_sale_single_attendee/views/event_type.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+        <record model="ir.ui.view" id="view_event_type_form">
+            <field name="name">event.type.form</field>
+            <field name="model">event.type</field>
+            <field name="inherit_id" ref="event.view_event_type_form" />
+            <field name="arch" type="xml">
+                <div name="event_type_attendees" position="inside">
+                    <div class="col-12 col-lg-6 o_setting_box" name="event_type_attendees_auto_confirm">
+                        <div class="o_setting_left_pane">
+                            <field name="single_attendee_registration"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="single_attendee_registration"/>
+                            <div class="row">
+                                <div class="col-lg-8 mt16 text-muted">
+                                    Ask for a single attendee at registration on the website
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </field>
+        </record>
+</odoo>


### PR DESCRIPTION
This module allows to define an event with 'Single Attendee Registration' so
that when a user registers on the website, he will not have to enter a name and
an email for each ticket, but only one name and one email, that will be used
as attendee for every ticket purchased.