### PR TITLE
[13.0][ADD] event_sale_portal : Module to display confirmed event registrations in the Sale Order portal page.

### DIFF
--- a/event_sale_portal/__init__.py
+++ b/event_sale_portal/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/event_sale_portal/__manifest__.py
+++ b/event_sale_portal/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Point of Sale Events",
+    "summary": "Sell events from Point of Sale",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/event",
+    "category": "Marketing",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "maintainers": ["ivantodorovich"],
+    "depends": ["event_sale"],
+    "data": ["views/templates.xml", "views/event_event.xml", "views/event_type.xml"],
+}

--- a/event_sale_portal/controllers/__init__.py
+++ b/event_sale_portal/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal

--- a/event_sale_portal/controllers/portal.py
+++ b/event_sale_portal/controllers/portal.py
@@ -1,0 +1,60 @@
+from odoo import http
+from odoo.exceptions import AccessError, MissingError
+from odoo.http import content_disposition, request
+
+from odoo.addons.portal.controllers.portal import CustomerPortal
+
+
+class CustomerPortal(CustomerPortal):
+    @http.route(
+        [
+            "/my/orders/<int:order_id>/event/<int:event_id>/badge",
+            "/my/orders/<int:order_id>/event/<int:event_id>/badge/<int:reg_id>",
+        ],
+        type="http",
+        auth="public",
+        website=True,
+    )
+    def portal_order_event_badge(
+        self, order_id, event_id, reg_id=None, access_token=None, download=False, **kw
+    ):
+        """Download event registration badges from sale order portal page."""
+        try:
+            order_sudo = self._document_check_access(
+                "sale.order", order_id, access_token=access_token
+            )
+        except (AccessError, MissingError):
+            return request.redirect("/my")
+        # Get sale order downloadable registrations
+        registrations = order_sudo.event_registration_ids.filtered(
+            lambda r: (
+                r.state == "open"
+                and r.event_id.id == event_id
+                and r.event_id.portal_badge_download
+            )
+        )
+        if not registrations:  # pragma: no cover
+            return request.redirect("/my")
+        # Check if registration_id belongs to the sale order
+        if reg_id is not None:
+            if reg_id not in registrations.ids:  # pragma: no cover
+                return request.redirect("/my")
+            registrations = registrations.browse(reg_id)
+        # Render report
+        report_sudo = request.env.ref("event.report_event_registration_badge").sudo()
+        report = report_sudo.render(registrations.ids)[0]
+        reporthttpheaders = [
+            ("Content-Type", "application/pdf"),
+            ("Content-Length", len(report)),
+        ]
+        # Download
+        if download:
+            filename = (
+                "Badges.pdf"
+                if len(registrations) > 1
+                else "Badge - %s.pdf" % registrations.name
+            )
+            reporthttpheaders.append(
+                ("Content-Disposition", content_disposition(filename))
+            )
+        return request.make_response(report, headers=reporthttpheaders)

--- a/event_sale_portal/models/__init__.py
+++ b/event_sale_portal/models/__init__.py
@@ -1,0 +1,3 @@
+from . import event_event
+from . import event_type
+from . import sale_order

--- a/event_sale_portal/models/event_event.py
+++ b/event_sale_portal/models/event_event.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class EventEvent(models.Model):
+    _inherit = "event.event"
+
+    portal_badge_download = fields.Boolean(
+        string="Portal Badge Download",
+        help="If set, a download link will be provider for the customer to "
+        "download badges directly from the Sale Order portal page.\n"
+        "Optionally, you can configure a specific report to use.",
+        default=True,
+    )
+
+    @api.onchange("event_type_id")
+    def _onchange_type(self):
+        res = super()._onchange_type()
+        if self.event_type_id:
+            self.portal_badge_download = self.event_type_id.portal_badge_download
+        return res

--- a/event_sale_portal/models/event_type.py
+++ b/event_sale_portal/models/event_type.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class EventType(models.Model):
+    _inherit = "event.type"
+
+    portal_badge_download = fields.Boolean(
+        string="Portal Badge Download",
+        help="If set, a download link will be provider for the customer to "
+        "download badges directly from the Sale Order portal page.\n"
+        "Optionally, you can configure a specific report to use.",
+        default=True,
+    )

--- a/event_sale_portal/models/sale_order.py
+++ b/event_sale_portal/models/sale_order.py
@@ -1,0 +1,10 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    event_registration_ids = fields.One2many("event.registration", "sale_order_id")

--- a/event_sale_portal/readme/CONFIGURE.rst
+++ b/event_sale_portal/readme/CONFIGURE.rst
@@ -1,0 +1,5 @@
+For the badges to be downloadable by the customer, you need to set the field
+*Portal Badge Download* on the event.event record.
+
+This field is set by default because it's what you normally expect when installing
+this module.

--- a/event_sale_portal/readme/CONTRIBUTORS.rst
+++ b/event_sale_portal/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/event_sale_portal/readme/DESCRIPTION.rst
+++ b/event_sale_portal/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Allows the customer to download event registration badges from the Sale Order portal page.

--- a/event_sale_portal/readme/USAGE.rst
+++ b/event_sale_portal/readme/USAGE.rst
@@ -1,0 +1,2 @@
+After buying event registrations, the customer is able to download the badges
+from the Sale Order portal page, as long as they're confirmed.

--- a/event_sale_portal/tests/__init__.py
+++ b/event_sale_portal/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_portal

--- a/event_sale_portal/tests/test_portal.py
+++ b/event_sale_portal/tests/test_portal.py
@@ -1,0 +1,295 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import re
+
+from lxml import etree
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestEventSalePortal(HttpCase):
+    def setUp(self):
+        super().setUp()
+        self.customer = self.env.ref("base.res_partner_3")
+        self.product_event = self.env.ref("event_sale.product_product_event")
+        # Create demo event
+        self.event = self.env["event.event"].create(
+            {
+                "name": "Test Portal Event",
+                "date_begin": "2022-06-20",
+                "date_end": "2022-06-23",
+                "portal_badge_download": True,
+            }
+        )
+        # Create tickets
+        self.ticket_adults = self.env["event.event.ticket"].create(
+            {
+                "name": "Adults",
+                "product_id": self.product_event.id,
+                "event_id": self.event.id,
+                "price": 15.00,
+            }
+        )
+        self.ticket_kids = self.env["event.event.ticket"].create(
+            {
+                "name": "Kids",
+                "product_id": self.product_event.id,
+                "event_id": self.event.id,
+                "price": 5.00,
+            }
+        )
+
+    def test_01_sale_order_portal(self):
+        # Create sale order
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_event.id,
+                            "name": "Event registration",
+                            "event_id": self.event.id,
+                            "event_ticket_id": self.ticket_adults.id,
+                            "price_unit": 15.00,
+                            "product_uom_qty": 1,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_event.id,
+                            "name": "Event registration",
+                            "event_id": self.event.id,
+                            "event_ticket_id": self.ticket_kids.id,
+                            "price_unit": 5.00,
+                            "product_uom_qty": 2,
+                        },
+                    ),
+                ],
+            }
+        )
+        # Confirm order and registrations
+        order.action_confirm()
+        order.order_line._update_registrations(confirm=True)
+        # Get portal url
+        res = self.url_open(order._get_share_url())
+        self.assertEqual(res.status_code, 200)
+        root = etree.fromstring(res.content, etree.HTMLParser())
+        # Check that we have registrations
+        section = root.xpath("//section[@id='event_registrations']")
+        self.assertEqual(
+            len(section), 1, "We should have the event registrations section"
+        )
+        # Check that we have the download button
+        buttons = root.xpath(
+            "//section[@id='event_registrations']"
+            "//td[@name='td_actions']"
+            "//a[hasclass('download')]"
+        )
+        self.assertEqual(len(buttons), 3)
+        # Check that we can download a single registration
+        href = buttons[0].attrib["href"]
+        res = self.url_open(href)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers["Content-Type"], "application/pdf")
+        # Check that we can download all event badges at once
+        button = root.xpath(
+            "//section[@id='event_registrations']//div//a[@title='Download all']"
+        )
+        self.assertEqual(len(button), 1, "We should have a Download all button")
+        href = button[0].attrib["href"]
+        res = self.url_open(href)
+        res = self.url_open(order._get_share_url())
+        self.assertEqual(res.status_code, 200)
+        root = etree.fromstring(res.content, etree.HTMLParser())
+
+    def test_02_sale_order_portal_no_download(self):
+        # Disable badge downloading on event
+        self.event.portal_badge_download = False
+        # Create sale order
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_event.id,
+                            "name": "Event registration",
+                            "event_id": self.event.id,
+                            "event_ticket_id": self.ticket_adults.id,
+                            "price_unit": 15.00,
+                            "product_uom_qty": 1,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_event.id,
+                            "name": "Event registration",
+                            "event_id": self.event.id,
+                            "event_ticket_id": self.ticket_kids.id,
+                            "price_unit": 5.00,
+                            "product_uom_qty": 2,
+                        },
+                    ),
+                ],
+            }
+        )
+        # Confirm order and registrations
+        order.action_confirm()
+        order.order_line._update_registrations(confirm=True)
+        # Get portal url
+        res = self.url_open(order._get_share_url())
+        self.assertEqual(res.status_code, 200)
+        root = etree.fromstring(res.content, etree.HTMLParser())
+        # Check that we have registrations
+        section = root.xpath("//section[@id='event_registrations']")
+        self.assertEqual(
+            len(section), 1, "We should have the event registrations section"
+        )
+        # Check that we aren't able to download registrations
+        buttons = root.xpath(
+            "//section[@id='event_registrations']"
+            "//td[@name='td_actions']"
+            "//a[hasclass('download')]"
+        )
+        self.assertEqual(len(buttons), 0)
+        # Check that we can't download all event badges at once
+        button = root.xpath(
+            "//section[@id='event_registrations']//div//a[@title='Download all']"
+        )
+        self.assertEqual(len(button), 0)
+
+    def test_02_sale_order_no_registrations(self):
+        # Create sale order
+        order = self.env["sale.order"].create({"partner_id": self.customer.id})
+        order.action_confirm()
+        # Get portal url
+        res = self.url_open(order._get_share_url())
+        self.assertEqual(res.status_code, 200)
+        root = etree.fromstring(res.content, etree.HTMLParser())
+        # Check that we don't have registrations
+        section = root.xpath("//section[@id='event_registrations']")
+        self.assertEqual(
+            len(section), 0, "We shouldn't have any event registrations section"
+        )
+
+    def test_03_sale_order_wrong_token_errors(self):
+        # Create sale order
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_event.id,
+                            "name": "Event registration",
+                            "event_id": self.event.id,
+                            "event_ticket_id": self.ticket_adults.id,
+                            "price_unit": 15.00,
+                            "product_uom_qty": 1,
+                        },
+                    ),
+                ],
+            }
+        )
+        # Confirm order and registrations
+        order.action_confirm()
+        order.order_line._update_registrations(confirm=True)
+        # Get portal url
+        order_url = order._get_share_url()
+        # Case 1: Attempt a to access with a different token
+        wrong_token_url = re.sub(r"(?<=access_token=)([^&]+)", "something", order_url,)
+        res = self.url_open(wrong_token_url)
+        self.assertEqual(res.status_code, 200, "Shouldn't raise any error")
+        self.assertNotEqual(res.url, order_url, "Should've been redirected")
+        # Case 2: Attempt to access with an unexistant sale order
+        wrong_order_url = re.sub(r"(?<=res_id=)([0-9]+)", str(order.id + 1), order_url,)
+        res = self.url_open(wrong_order_url)
+        self.assertEqual(res.status_code, 200, "Shouldn't raise any error")
+        self.assertNotEqual(res.url, order_url, "Should've been redirected")
+
+    def test_04_download_badge_another_order(self):
+        # Create sale orders
+        order1 = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_event.id,
+                            "name": "Event registration",
+                            "event_id": self.event.id,
+                            "event_ticket_id": self.ticket_adults.id,
+                            "price_unit": 15.00,
+                            "product_uom_qty": 1,
+                        },
+                    ),
+                ],
+            }
+        )
+        order2 = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_event.id,
+                            "name": "Event registration",
+                            "event_id": self.event.id,
+                            "event_ticket_id": self.ticket_adults.id,
+                            "price_unit": 15.00,
+                            "product_uom_qty": 1,
+                        },
+                    ),
+                ],
+            }
+        )
+        # Confirm order and registrations
+        order1.action_confirm()
+        order2.action_confirm()
+        order1.order_line._update_registrations(confirm=True)
+        order2.order_line._update_registrations(confirm=True)
+        # Get portal url
+        badge_url = "/my/orders/%d/event/%d/badge/%d?access_token=%s"
+        order_url = order1._get_share_url()
+        access_token = re.search(r"(?<=access_token=)([^&]+)", order_url).group(0)
+        # Attempt to download a badge from this order
+        res = self.url_open(
+            badge_url
+            % (
+                order1.id,
+                self.event.id,
+                order1.event_registration_ids[0].id,
+                access_token,
+            )
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers["Content-Type"], "application/pdf")
+        # Attempt to download a badge from another order
+        res = self.url_open(
+            badge_url
+            % (
+                order1.id,
+                self.event.id,
+                order2.event_registration_ids[0].id,
+                access_token,
+            )
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertNotEqual(res.headers["Content-Type"], "application/pdf")

--- a/event_sale_portal/views/event_event.xml
+++ b/event_sale_portal/views/event_event.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2021 Camptocamp - Iván Todorovich
+    License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+-->
+<odoo>
+    <record id="view_event_form" model="ir.ui.view">
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_form" />
+        <field name="priority" eval="50" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='auto_confirm']//parent::group"
+                position="inside"
+            >
+                <field name="portal_badge_download" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/event_sale_portal/views/event_type.xml
+++ b/event_sale_portal/views/event_type.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2021 Camptocamp - Iván Todorovich
+    License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+-->
+<odoo>
+    <record id="view_event_type_form" model="ir.ui.view">
+        <field name="model">event.type</field>
+        <field name="inherit_id" ref="event.view_event_type_form" />
+        <field name="arch" type="xml">
+            <div name="event_type_communication" position="inside">
+                <div class="col-12 col-lg-6 o_setting_box" name="event_type_portal">
+                    <div class="o_setting_left_pane">
+                        <field name="portal_badge_download" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="portal_badge_download" />
+                        <div class="row">
+                            <div class="col-lg-8 mt16 text-muted">
+                                If set, a download link will be provider for the customer to
+                                download badges directly from the Sale Order portal page.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/event_sale_portal/views/templates.xml
+++ b/event_sale_portal/views/templates.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2021 Camptocamp SA - Iván Todorovich
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <template id="sale_order_portal_content_event_registrations">
+        <h5 class="mt-4" t-field="event.display_name" />
+        <table class="table table-sm">
+            <thead class="bg-100">
+                <tr>
+                    <th name="th_registration" class="text-left">Registration</th>
+                    <th name="th_event" class="text-left">Ticket</th>
+                    <th
+                        t-if="event.portal_badge_download"
+                        name="th_badge"
+                        class="text-center"
+                    />
+                </tr>
+            </thead>
+            <tbody>
+                <tr t-foreach="registrations" t-as="registration">
+                    <td name="td_event">
+                        <div t-if="registration.name" t-field="registration.name" />
+                        <div t-if="registration.email" t-field="registration.email" />
+                        <div t-if="registration.phone" t-field="registration.phone" />
+                    </td>
+                    <td name="td_event">
+                        <div t-field="registration.event_ticket_id.display_name" />
+                    </td>
+                    <td
+                        t-if="event.portal_badge_download"
+                        name="td_actions"
+                        class="text-right"
+                    >
+                        <a
+                            t-attf-href="/my/orders/#{sale_order.id}/event/#{event.id}/badge/#{registration.id}?access_token=#{token}&amp;download=true"
+                            class="btn btn-link download"
+                        >
+                            <i class="fa fa-download" />
+                        </a>
+                        <a
+                            t-attf-href="/my/orders/#{sale_order.id}/event/#{event.id}/badge/#{registration.id}?access_token=#{token}"
+                            class="btn btn-link print"
+                        >
+                            <i class="fa fa-print" />
+                        </a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <div class="mt-8 text-right" t-if="event.portal_badge_download">
+            <a
+                class="btn btn-link"
+                title="Download all"
+                t-attf-href="/my/orders/#{sale_order.id}/event/#{event.id}/badge?access_token=#{token}&amp;download=true"
+            >
+                <i class="fa fa-download" /> Download all
+            </a>
+            <a
+                class="btn btn-link"
+                title="Print all badges"
+                t-attf-href="/my/orders/#{sale_order.id}/event/#{event.id}/badge?access_token=#{token}"
+            >
+                <i class="fa fa-print" /> Print all
+            </a>
+        </div>
+    </template>
+    <template
+        id="sale_order_portal_content"
+        inherit_id="sale.sale_order_portal_content"
+        name="Event registrations"
+        priority="100"
+    >
+        <xpath expr="//section[@id='details']//parent::div" position="inside">
+            <t
+                t-set="confirmed_registrations"
+                t-value="sale_order.event_registration_ids.filtered(lambda r: r.state == 'open')"
+            />
+            <t t-set="events" t-value="confirmed_registrations.mapped('event_id')" />
+            <section
+                t-if="confirmed_registrations"
+                class="mt-5"
+                id="event_registrations"
+                name="Event Registrations"
+            >
+                <h3>Event Registrations</h3>
+                <t t-foreach="events" t-as="event">
+                    <t
+                        t-call="event_sale_portal.sale_order_portal_content_event_registrations"
+                    >
+                        <t
+                            t-set="registrations"
+                            t-value="confirmed_registrations.filtered(lambda r: r.event_id == event)"
+                        />
+                    </t>
+                </t>
+            </section>
+        </xpath>
+    </template>
+</odoo>

--- a/setup/event_sale_portal/odoo/addons/event_sale_portal
+++ b/setup/event_sale_portal/odoo/addons/event_sale_portal
@@ -1,0 +1,1 @@
+../../../../event_sale_portal

--- a/setup/event_sale_portal/setup.py
+++ b/setup/event_sale_portal/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Displays the event registrations in the sale order portal page, and allows the user to download the event badges.

![portal](https://user-images.githubusercontent.com/1914185/119992116-962aec00-bfa0-11eb-8b6c-8e18f29fba0a.png)
