### PR TITLE
[13.0][FIX] event_session: Error when seats_max is 0

### DIFF
--- a/event_session/models/event_session.py
+++ b/event_session/models/event_session.py
@@ -249,6 +249,10 @@ class EventSession(models.Model):
                 session[state_field[res["state"]]] += res["__count"]
         # compute seats_available
         for session in self:
+            # We need to initialize the values to avoid Unexpected error when we access
+            # to the sessions when the session has no limit of seats (seats_max = 0).
+            session.seats_available = 0
+            session.seats_available_pc = 0
             if session.seats_max > 0:
                 session.seats_available = session.seats_max - (
                     session.seats_reserved + session.seats_used


### PR DESCRIPTION
When we create a session with seats_max = 0, we get an error when we try to view it.

Doing this changes we achieve to avoid None values on the fields seats_available and seats_available_pc.

cc @Tecnativa TT29930