### PR TITLE
[12.0][FIX] event_registration_multi_qty: Force quantity despite default

### DIFF
--- a/event_registration_multi_qty/models/event.py
+++ b/event_registration_multi_qty/models/event.py
@@ -77,3 +77,12 @@ class EventRegistration(models.Model):
                     _('You can not add quantities if you not active the'
                       ' option "Allow multiple attendees per registration"'
                       ' in event'))
+
+    @api.model
+    def _prepare_attendee_values(self, registration):
+        res = super()._prepare_attendee_values(registration)
+        # Passed fields are not taken into account if a default is set,
+        # so we need to force this
+        if "qty" in registration:
+            res.update({"qty": registration.get("qty")})
+        return res


### PR DESCRIPTION
After https://github.com/odoo/odoo/commit/a4d50b468c8f37155048e2c7bb0c816f45d27a95, the passed value is not taken into account when a default value is set on the field.
This forces the update to the quantity.

cc @Tecnativa @chienandalu