### PR TITLE
[13.0][FIX] event_session: Attendee count failed

### DIFF
--- a/event_session/README.rst
+++ b/event_session/README.rst
@@ -64,8 +64,9 @@ Contributors
 
 * `Tecnativa <https://www.tecnativa.com>`__:
 
-  * Sergio Teruel <sergio.teruel@tecnativa.com>
-  * David Vidal <david.vidal@tecnativa.com>
+  * Sergio Teruel
+  * David Vidal
+  * Carlos Roca
 
 * Nikos Tsirintanis <ntsirintanis@therp.nl>
 * David Alonso <david.alonso@solvos.es>

--- a/event_session/readme/CONTRIBUTORS.rst
+++ b/event_session/readme/CONTRIBUTORS.rst
@@ -1,7 +1,8 @@
 * `Tecnativa <https://www.tecnativa.com>`__:
 
-  * Sergio Teruel <sergio.teruel@tecnativa.com>
-  * David Vidal <david.vidal@tecnativa.com>
+  * Sergio Teruel
+  * David Vidal
+  * Carlos Roca
 
 * Nikos Tsirintanis <ntsirintanis@therp.nl>
 * David Alonso <david.alonso@solvos.es>

--- a/event_session/static/description/index.html
+++ b/event_session/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Event Sessions</title>
 <style type="text/css">
 
@@ -411,8 +411,9 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
-<li>Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt;</li>
-<li>David Vidal &lt;<a class="reference external" href="mailto:david.vidal&#64;tecnativa.com">david.vidal&#64;tecnativa.com</a>&gt;</li>
+<li>Sergio Teruel</li>
+<li>David Vidal</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 <li>Nikos Tsirintanis &lt;<a class="reference external" href="mailto:ntsirintanis&#64;therp.nl">ntsirintanis&#64;therp.nl</a>&gt;</li>


### PR DESCRIPTION
Attendee count is failing because records are being accumulated without taking into account possible changes in event.registration. See the gif bellow:
![Peek 01-06-2021 12-17](https://user-images.githubusercontent.com/35952655/120307923-d0172d80-c2d3-11eb-9c46-1495935b9bb3.gif)

With these changes, it is possible to correctly calculate the count of attendees.

cc @Tecnativa TT29930