### PR TITLE
[13.0][ADD] event_mail_group_by_email

### DIFF
--- a/event_mail_group_by_email/__init__.py
+++ b/event_mail_group_by_email/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/event_mail_group_by_email/__manifest__.py
+++ b/event_mail_group_by_email/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Event Mail Group by Email",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/event",
+    "category": "Marketing",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "maintainers": ["ivantodorovich"],
+    "depends": ["event"],
+    "data": ["views/event_event.xml", "views/event_type.xml"],
+}

--- a/event_mail_group_by_email/models/__init__.py
+++ b/event_mail_group_by_email/models/__init__.py
@@ -1,0 +1,6 @@
+from . import event_event
+from . import event_registration
+from . import event_type_mail
+from . import event_mail
+from . import event_mail_registration
+from . import mail_template

--- a/event_mail_group_by_email/models/event_event.py
+++ b/event_mail_group_by_email/models/event_event.py
@@ -1,0 +1,48 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, models
+
+
+class EventEvent(models.Model):
+    _inherit = "event.event"
+
+    def _mail_attendee_group(self, template, attendees, force_send=False):
+        """Send an email notification to an attendee group."""
+        if not attendees:
+            return False  # pragma: no cover
+        main_attendee = attendees[0]
+        # Send email to main attendee
+        template.with_context(records=attendees).send_mail(
+            main_attendee.id, force_send=force_send
+        )
+        # Post a note in the others
+        other_attendees = attendees - main_attendee
+        if other_attendees:
+            reg_url = '<a href="#model=event.registration&id=%d">%s</a>'
+            body = _(
+                "Communication <b>%s</b> sent to attendee " "with the same email: %s."
+            ) % (
+                template.display_name,
+                reg_url % (main_attendee.id, main_attendee.display_name),
+            )
+            for attendee in other_attendees:
+                attendee.message_post(body=body)
+
+    def mail_attendees(
+        self,
+        template_id,
+        force_send=False,
+        filter_func=lambda self: self.state != "cancel",
+    ):
+        # Override. Group by email when context key is present
+        if not self.env.context.get("group_by_email"):
+            return super().mail_attendees(
+                template_id, force_send=force_send, filter_func=filter_func
+            )
+        template = self.env["mail.template"].browse(template_id)
+        for event in self:
+            event_attendees = event.registration_ids.filtered(filter_func)
+            attendee_groups = event_attendees._group_by_email()
+            for attendees in attendee_groups:
+                self._mail_attendee_group(template, attendees, force_send=force_send)

--- a/event_mail_group_by_email/models/event_mail.py
+++ b/event_mail_group_by_email/models/event_mail.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class EventMail(models.Model):
+    _inherit = "event.mail"
+
+    group_by_email = fields.Boolean(
+        string="Group by email",
+        help="If enabled, in the case of multiple registrations having "
+        "the same email address, a single grouped email will be sent.\n\n"
+        "NOTE: If the email template has a report, it will be rendered for "
+        "all registrations and attached in separate files.\n"
+        "The registrations recordset is available in the context and can be used "
+        "to render the email body. ie: object.env.context.get('records').",
+        default=True,
+    )
+
+    def execute(self):
+        # Override. Split super() calls in two, adding the context key
+        # group_by_email when needed
+        grouped = self.filtered("group_by_email")
+        return (
+            super(EventMail, self - grouped).execute()
+            and super(EventMail, grouped.with_context(group_by_email=True)).execute()
+        )

--- a/event_mail_group_by_email/models/event_mail_registration.py
+++ b/event_mail_group_by_email/models/event_mail_registration.py
@@ -1,0 +1,49 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class EventMailRegistration(models.Model):
+    _inherit = "event.mail.registration"
+
+    def _group_by_email(self):
+        """Returns a list of recordsets, grouped by email address"""
+        res = []
+        email_to_rec_ids = {}
+        for rec in self:
+            reg = rec.registration_id
+            email = reg.email or reg.partner_id.email
+            # If there's no email, add directly to result, ungrouped
+            if email:
+                email_to_rec_ids.setdefault(email, []).append(rec.id)
+            else:  # pragma: no cover
+                res.append(rec)
+        # Add groups to result
+        for __, rec_ids in email_to_rec_ids.items():
+            res.append(self.browse(rec_ids))
+        return res
+
+    def execute(self):
+        # Override. Handle group_by_email
+        if not self.env.context.get("group_by_email"):
+            return super().execute()
+        # Group by scheduler
+        schedulers = self.mapped("scheduler_id")
+        for scheduler in schedulers:
+            # Scheduler mails
+            mails_to_send = self.filtered(
+                lambda mail: (
+                    not mail.mail_sent
+                    and mail.scheduler_id.id == scheduler.id
+                    and mail.registration_id.state in ["open", "done"]
+                    and mail.scheduler_id.notification_type == "mail"
+                )
+            )
+            mails_grouped = mails_to_send._group_by_email()
+            for mails in mails_grouped:
+                scheduler.event_id._mail_attendee_group(
+                    scheduler.template_id, mails.mapped("registration_id")
+                )
+                # Mark all as sent
+                mails.write({"mail_sent": True})

--- a/event_mail_group_by_email/models/event_registration.py
+++ b/event_mail_group_by_email/models/event_registration.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class EventRegistration(models.Model):
+    _inherit = "event.registration"
+
+    def _group_by_email(self):
+        """Returns a list of attendee recordsets, grouped by email address"""
+        res = []
+        email_to_rec_ids = {}
+        for rec in self:
+            email = rec.email or rec.partner_id.email
+            # If there's no email, add directly to result, ungrouped
+            if email:
+                email_to_rec_ids.setdefault(email, []).append(rec.id)
+            else:  # pragma: no cover
+                res.append(rec)
+        # Add groups to result
+        for __, rec_ids in email_to_rec_ids.items():
+            res.append(self.browse(rec_ids))
+        return res

--- a/event_mail_group_by_email/models/event_type_mail.py
+++ b/event_mail_group_by_email/models/event_type_mail.py
@@ -1,0 +1,27 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class EventTypeMail(models.Model):
+    _inherit = "event.type.mail"
+
+    group_by_email = fields.Boolean(
+        string="Group by email",
+        help="If enabled, in the case of multiple registrations having "
+        "the same email address, a single grouped email will be sent.\n\n"
+        "NOTE: If the email template has a report, it will be rendered for "
+        "all registrations and attached in separate files.\n"
+        "The registrations recordset is available in the context and can be used "
+        "to render the email body. ie: object.env.context.get('records').",
+        default=True,
+    )
+
+    @api.model
+    def _get_event_mail_fields_whitelist(self):
+        # Override. Add group_by_email field to whitelist so that
+        # it's copied from Event Type when it changes.
+        res = super()._get_event_mail_fields_whitelist()
+        res.append("group_by_email")
+        return res

--- a/event_mail_group_by_email/models/mail_template.py
+++ b/event_mail_group_by_email/models/mail_template.py
@@ -1,0 +1,62 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import base64
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class MailTemplate(models.Model):
+    _inherit = "mail.template"
+
+    def _get_extra_records_attachments(self, res_ids):
+        self.ensure_one()
+        attachments = []
+        for res_id in res_ids:
+            # Get the language contextualized template corresponding to the record
+            template = self.get_email_template(res_id)
+            # Generate the report for all records and add to attachments
+            report = template.report_template
+            report_name = self._render_template(
+                template.report_name, template.model, res_id
+            )
+            report_service = report.report_name
+            if report.report_type in ["qweb-html", "qweb-pdf"]:
+                report_result, report_format = report.render_qweb_pdf([res_id])
+            else:  # pragma: no cover
+                res = report.render([res_id])
+                if not res:
+                    raise UserError(
+                        _("Unsupported report type %s found.") % report.report_type
+                    )
+                report_result, report_format = res
+            # Prepare attachment
+            report_result = base64.b64encode(report_result)
+            if not report_name:  # pragma: no cover
+                report_name = "report." + report_service
+            ext = "." + report_format
+            if not report_name.endswith(ext):
+                report_name += ext
+            # Add attachment to results
+            attachments.append((report_name, report_result))
+        return attachments
+
+    def generate_email(self, res_ids, fields=None):
+        # If records is available in context, and the template has a report,
+        # render and attach reports for all extra record.
+        # Note: multi_mode is out of scope.
+        self.ensure_one()
+        res = super().generate_email(res_ids, fields=fields)
+        records = self.env.context.get("records")
+        if (
+            self.env.context.get("group_by_email")
+            and records
+            and self.report_template
+            and isinstance(res_ids, int)
+        ):
+            extra_res_ids = list(set(records.ids) - {res_ids})
+            extra_attachments = self._get_extra_records_attachments(extra_res_ids)
+            res.setdefault("attachments", [])
+            res["attachments"] += extra_attachments
+        return res

--- a/event_mail_group_by_email/readme/CONFIGURE.rst
+++ b/event_mail_group_by_email/readme/CONFIGURE.rst
@@ -1,0 +1,1 @@
+On the desired event mail communication, enable "Group by email".

--- a/event_mail_group_by_email/readme/CONTRIBUTORS.rst
+++ b/event_mail_group_by_email/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/event_mail_group_by_email/readme/DESCRIPTION.rst
+++ b/event_mail_group_by_email/readme/DESCRIPTION.rst
@@ -1,0 +1,11 @@
+This module allows to group event communications by registration email address,
+and by doing so avoid flooding the customer's inbox.
+
+When enabled, if there are multiple registrations with the same email address,
+only one email will be sent.
+
+If the email template has a report, it will be rendered for all the
+attendees in the group and attached to the same email.
+
+The attendees recordset can be accessed through the context to customize the
+email template's content. It's available in the context key 'records'.

--- a/event_mail_group_by_email/readme/ROADMAP.rst
+++ b/event_mail_group_by_email/readme/ROADMAP.rst
@@ -1,0 +1,8 @@
+If Auto confirm registrations is enabled on the event, and the mail scheduler
+is configured to send emails after each registration, no grouping will be applied.
+
+This is because the scheduler would be executed one by one for each new confirmed
+registration.
+
+However, the grouping works as expected when confirming multiple registrations at once,
+which is the case in normal event sale workflows.

--- a/event_mail_group_by_email/tests/__init__.py
+++ b/event_mail_group_by_email/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mail_schedule

--- a/event_mail_group_by_email/tests/test_mail_schedule.py
+++ b/event_mail_group_by_email/tests/test_mail_schedule.py
@@ -1,0 +1,235 @@
+# Copyright 2021 Camptocamp SA - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields
+from odoo.tests import common
+
+
+class TestMailSchedule(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.template_badge = cls.env.ref("event.event_registration_mail_template_badge")
+        cls.template_subscription = cls.env.ref("event.event_subscription")
+        cls.template_reminder = cls.env.ref("event.event_reminder")
+        cls.event = cls.env["event.event"].create(
+            {
+                "name": "Test Event",
+                "auto_confirm": False,
+                "date_begin": fields.Datetime.now() + relativedelta(days=1),
+                "date_end": fields.Datetime.now() + relativedelta(days=15),
+            }
+        )
+        # Registrations
+        cls.reg_1 = cls.env["event.registration"].create(
+            {
+                "event_id": cls.event.id,
+                "name": "Jon Snow",
+                "email": "the.black.crow@nigthswatch.org",
+            }
+        )
+        cls.reg_2 = cls.env["event.registration"].create(
+            {
+                "event_id": cls.event.id,
+                "name": "Samwell Tarly",
+                "email": "the.black.crow@nigthswatch.org",
+            }
+        )
+        cls.reg_3 = cls.env["event.registration"].create(
+            {
+                "event_id": cls.event.id,
+                "name": "Daenerys Targaryen",
+                "email": "queen.of.everything@fire.io",
+            }
+        )
+        cls.registrations = cls.reg_1 | cls.reg_2 | cls.reg_3
+
+    def _get_event_registrations_mails(self, registration):
+        return self.env["mail.mail"].search(
+            [("model", "=", "event.registration"), ("res_id", "in", registration.ids)]
+        )
+
+    def test_00_after_sub_grouped(self):
+        # Configure event
+        self.event.event_mail_ids = [
+            (5, 0),
+            (
+                0,
+                0,
+                {
+                    "interval_unit": "now",
+                    "interval_type": "after_sub",
+                    "group_by_email": True,
+                    "template_id": self.template_badge.id,
+                },
+            ),
+        ]
+        # After registration confirmation, mails should be grouped
+        self.registrations.confirm_registration()
+        mails = self._get_event_registrations_mails(self.registrations)
+        self.assertEqual(len(mails), 2, "Only two emails should've been sent")
+        # Reg 1
+        reg_1_mails = self._get_event_registrations_mails(self.reg_1)
+        self.assertEqual(len(reg_1_mails), 1, "Reg 1 should've received 1 email.")
+        self.assertEqual(
+            len(reg_1_mails.attachment_ids), 2, "Both badges should be in the email."
+        )
+        # Reg 2
+        reg_2_mails = self._get_event_registrations_mails(self.reg_2)
+        self.assertEqual(
+            len(reg_2_mails), 0, "Reg 2 shouldn't have received any email."
+        )
+        # Reg 3
+        reg_3_mails = self._get_event_registrations_mails(self.reg_3)
+        self.assertEqual(len(reg_3_mails), 1, "Reg 3 should've received 1 email.")
+        self.assertEqual(
+            len(reg_3_mails.attachment_ids), 1, "Only one badge in the email."
+        )
+
+    def test_01_after_sub_ungrouped(self):
+        # Configure event
+        self.event.event_mail_ids = [
+            (5, 0),
+            (
+                0,
+                0,
+                {
+                    "interval_unit": "now",
+                    "interval_type": "after_sub",
+                    "group_by_email": False,
+                    "template_id": self.template_badge.id,
+                },
+            ),
+        ]
+        # Default behaviour is expected, no groupings
+        self.registrations.confirm_registration()
+        mails = self._get_event_registrations_mails(self.registrations)
+        self.assertEqual(len(mails), 3, "3 emails should've been sent")
+        # Reg 1
+        reg_1_mails = self._get_event_registrations_mails(self.reg_1)
+        self.assertEqual(len(reg_1_mails), 1, "Reg 1 should've received 1 email.")
+        self.assertEqual(
+            len(reg_1_mails.attachment_ids), 1, "One badge should be in the email."
+        )
+        # Reg 2
+        reg_2_mails = self._get_event_registrations_mails(self.reg_2)
+        self.assertEqual(len(reg_2_mails), 1, "Reg 2 should've received 1 email.")
+        self.assertEqual(
+            len(reg_2_mails.attachment_ids), 1, "One badge should be in the email."
+        )
+        # Reg 3
+        reg_3_mails = self._get_event_registrations_mails(self.reg_3)
+        self.assertEqual(len(reg_3_mails), 1, "Reg 3 should've received 1 email.")
+        self.assertEqual(
+            len(reg_3_mails.attachment_ids), 1, "One badge should be in the email."
+        )
+
+    def test_03_before_event_grouped(self):
+        # Configure event
+        self.event.event_mail_ids = [
+            (5, 0),
+            (
+                0,
+                0,
+                {
+                    "interval_nbr": 1,
+                    "interval_unit": "days",
+                    "interval_type": "before_event",
+                    "group_by_email": True,
+                    "template_id": self.template_badge.id,
+                },
+            ),
+        ]
+        # After registration confirmation, mails should be grouped
+        self.registrations.confirm_registration()
+        # Execute schedulers manually
+        self.event.event_mail_ids.execute()
+        # Check
+        mails = self._get_event_registrations_mails(self.registrations)
+        self.assertEqual(len(mails), 2, "Only 2 emails should've been sent")
+        # Reg 1
+        reg_1_mails = self._get_event_registrations_mails(self.reg_1)
+        self.assertEqual(len(reg_1_mails), 1, "Reg 1 should've received 1 email.")
+        self.assertEqual(
+            len(reg_1_mails.attachment_ids), 2, "Both badges should be in the email."
+        )
+        # Reg 2
+        reg_2_mails = self._get_event_registrations_mails(self.reg_2)
+        self.assertEqual(
+            len(reg_2_mails), 0, "Reg 2 shouldn't have received any email."
+        )
+
+    def test_04_before_event_ungrouped(self):
+        # Configure event
+        self.event.event_mail_ids = [
+            (5, 0),
+            (
+                0,
+                0,
+                {
+                    "interval_nbr": 1,
+                    "interval_unit": "days",
+                    "interval_type": "before_event",
+                    "group_by_email": False,
+                    "template_id": self.template_badge.id,
+                },
+            ),
+        ]
+        # After registration confirmation, mails should be grouped
+        self.registrations.confirm_registration()
+        # Execute schedulers manually
+        self.event.event_mail_ids.execute()
+        # Check
+        mails = self._get_event_registrations_mails(self.registrations)
+        self.assertEqual(len(mails), 3, "3 emails should've been sent")
+        # Reg 1
+        reg_1_mails = self._get_event_registrations_mails(self.reg_1)
+        self.assertEqual(len(reg_1_mails), 1, "Reg 1 should've received 1 email.")
+        self.assertEqual(
+            len(reg_1_mails.attachment_ids), 1, "Only one badge should be in the email."
+        )
+        # Reg 2
+        reg_2_mails = self._get_event_registrations_mails(self.reg_2)
+        self.assertEqual(len(reg_2_mails), 1, "Reg 2 should've received 1 email.")
+        self.assertEqual(
+            len(reg_2_mails.attachment_ids), 1, "Only one badge should be in the email."
+        )
+
+    def test_05_onchange_event_type(self):
+        event_type = self.env["event.type"].create(
+            {
+                "name": "Test Event Type",
+                "event_type_mail_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "interval_unit": "now",
+                            "interval_type": "after_sub",
+                            "group_by_email": True,
+                            "template_id": self.template_badge.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "interval_nbr": 1,
+                            "interval_unit": "days",
+                            "interval_type": "before_event",
+                            "group_by_email": True,
+                            "template_id": self.template_badge.id,
+                        },
+                    ),
+                ],
+            }
+        )
+        self.assertEqual(len(self.event.event_mail_ids), 0)
+        self.event.event_type_id = event_type.id
+        self.event._onchange_type()
+        self.assertEqual(len(self.event.event_mail_ids), 2)
+        for mail in self.event.event_mail_ids:
+            self.assertTrue(mail.group_by_email)

--- a/event_mail_group_by_email/views/event_event.xml
+++ b/event_mail_group_by_email/views/event_event.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2021 Camptocamp - Iván Todorovich
+    License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+-->
+<odoo>
+    <record id="view_event_form" model="ir.ui.view">
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='event_mail_ids']//tree" position="inside">
+                <field
+                    name="group_by_email"
+                    widget="boolean_toggle"
+                    attrs="{'readonly': [('notification_type', '!=', 'mail')]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/event_mail_group_by_email/views/event_type.xml
+++ b/event_mail_group_by_email/views/event_type.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2021 Camptocamp - Iván Todorovich
+    License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+-->
+<odoo>
+    <record id="view_event_type_form" model="ir.ui.view">
+        <field name="model">event.type</field>
+        <field name="inherit_id" ref="event.view_event_type_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='event_type_mail_ids']//tree" position="inside">
+                <field
+                    name="group_by_email"
+                    widget="boolean_toggle"
+                    attrs="{'readonly': [('notification_type', '!=', 'mail')]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/event_mail_group_by_email/odoo/addons/event_mail_group_by_email
+++ b/setup/event_mail_group_by_email/odoo/addons/event_mail_group_by_email
@@ -1,0 +1,1 @@
+../../../../event_mail_group_by_email

--- a/setup/event_mail_group_by_email/setup.py
+++ b/setup/event_mail_group_by_email/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to group event email communications by email address, and by doing so avoid flooding the customer's inbox. When enabled, if there are multiple registrations with the same email address, only one email will be sent.

If the email template has a report (for example, the registration badge), it will be rendered for all the attendees in the group and attached to the same email.

The attendees recordset can be accessed through the context to customize the email template's content. It's available in the context key 'records'.
