### PR TITLE
[FIX] website_event_filter_selector: ignore events from other websites

### DIFF
--- a/website_event_filter_selector/controllers/main.py
+++ b/website_event_filter_selector/controllers/main.py
@@ -16,7 +16,9 @@ class WebsiteEvent(WebsiteEventController):
 
         # Regenerate current domain. Ideally, upstream would make all this in a
         # separate method and make our life easier, but not happening now.
-        domain = [("state", "in", ("draft", "confirm", "done"))]
+        domain = http.request.website.website_domain() + [
+            ("state", "in", ("draft", "confirm", "done")),
+        ]
 
         def dom_without(without):
             return [leaf for leaf in domain if leaf[0] not in without]


### PR DESCRIPTION
To reproduce the problem:

1. Create an event on website 2.
2. Do not publish it.
3. Go to website 1.

If you were logged in, that event still appeared as unpublished. It shouldn't happen because it belongs to other website, no matter whether it is published or not.

@Tecnativa TT29748