### PR TITLE
[15.0][ADD] website_event_sale_cart_quantity_readonly

### DIFF
--- a/setup/website_event_sale_cart_quantity_readonly/odoo/addons/website_event_sale_cart_quantity_readonly
+++ b/setup/website_event_sale_cart_quantity_readonly/odoo/addons/website_event_sale_cart_quantity_readonly
@@ -1,0 +1,1 @@
+../../../../website_event_sale_cart_quantity_readonly

--- a/setup/website_event_sale_cart_quantity_readonly/setup.py
+++ b/setup/website_event_sale_cart_quantity_readonly/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/website_event_sale_cart_quantity_readonly/__manifest__.py
+++ b/website_event_sale_cart_quantity_readonly/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Moka Tourisme (https://www.mokatourisme.fr).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Website Event Sale: Cart Quantity Readonly",
+    "summary": "Prevent the user to change the quantity of an event in the cart",
+    "version": "15.0.1.0.0",
+    "author": "Moka Tourisme, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/OCA/event",
+    "license": "AGPL-3",
+    "category": "Others",
+    "depends": ["website_event_sale"],
+    "data": ["templates/cart.xml"],
+}

--- a/website_event_sale_cart_quantity_readonly/readme/CONTRIBUTORS.rst
+++ b/website_event_sale_cart_quantity_readonly/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Moka Tourisme <https://www.mokatourisme.fr>`_
+
+    * Iván Todorovich <ivan.todorovich@gmail.com>

--- a/website_event_sale_cart_quantity_readonly/readme/DESCRIPTION.rst
+++ b/website_event_sale_cart_quantity_readonly/readme/DESCRIPTION.rst
@@ -1,0 +1,9 @@
+This module makes the cart line quantity readonly for event tickets sold on website.
+
+If the website customer wants to change the ticket quantity, (s)he has to remove the
+line instead, and add new registrations from the event page.
+
+This module is created to overcome these issues in the core workflow:
+
+* https://github.com/odoo/odoo/issues/73058
+* https://github.com/odoo/odoo/issues/84947

--- a/website_event_sale_cart_quantity_readonly/templates/cart.xml
+++ b/website_event_sale_cart_quantity_readonly/templates/cart.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2022 Moka Tourisme (https://www.mokatourisme.fr).
+    @author Iván Todorovich <ivan.todorovich@gmail.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <template id="cart_lines" inherit_id="website_sale.cart_lines">
+        <xpath
+            expr="//div[hasclass('css_quantity')]/t[contains(@t-if, 'not line._is_not_sellable_line()')]"
+            position="attributes"
+        >
+            <attribute name="t-if" separator=" and " add="not line.event_ok" />
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
This module makes the cart line quantity readonly for event tickets sold on website.

If the website customer wants to change the ticket quantity, (s)he has to remove the line instead, and add new registrations from the event page.

This module is created to overcome these issues in the core workflow:

* https://github.com/odoo/odoo/issues/73058
* https://github.com/odoo/odoo/issues/84947