### PR TITLE
[13.0][FIX] website_event_filter_city: search input

### DIFF
--- a/website_event_filter_city/models/event.py
+++ b/website_event_filter_city/models/event.py
@@ -1,10 +1,39 @@
 # Copyright 2016-2017 Tecnativa - Jairo Llopis
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.osv import expression
 
 
 class EventEvent(models.Model):
     _inherit = "event.event"
 
     city = fields.Char(related="address_id.city", store=True)
+
+    def _patch_event_filter_city_domain(self, domain, city):
+        return expression.AND([domain, [("city", "=", city)]])
+
+    @api.model
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        event_filter_city = self.env.context.get("event_filter_city")
+        if event_filter_city:
+            args = self._patch_event_filter_city_domain(args, event_filter_city)
+        return super().search(
+            args, offset=offset, limit=limit, order=order, count=count
+        )
+
+    @api.model
+    def read_group(
+        self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True
+    ):
+        event_filter_city = self.env.context.get("event_filter_city")
+        if event_filter_city:
+            domain = self._patch_event_filter_city_domain(domain, event_filter_city)
+        return super().read_group(
+            domain,
+            fields,
+            groupby,
+            offset=offset,
+            limit=limit,
+            orderby=orderby,
+            lazy=lazy,
+        )

--- a/website_event_filter_city/static/src/js/website_event_filter_city.tour.js
+++ b/website_event_filter_city/static/src/js/website_event_filter_city.tour.js
@@ -42,7 +42,6 @@ odoo.define("website_event_filter_city.tour", function(require) {
             {
                 extra_trigger:
                     "#o_wevent_index_main_col:contains('Barcelona Days 2017')" +
-                    ":not(:contains('Online Code Sprint 2018'))" +
                     ":contains('Sevilla Code Sprint 2018')" +
                     ":contains('Sevilla Awesome Breakfast 2018')",
                 trigger: "a.dropdown-item:contains('Sevilla')",


### PR DESCRIPTION
- Refactor to try to reuse as much from the core as possible. Anyway, as there's no external method to compose the domain we still have to redo some things in order to add our city filter stuff.
- Consider the new name search term.
- Fix test: it didn't expect online events when filtering by country, but Odoo core allows it explicitly.

cc @Tecnativa TT34958

