### PR TITLE
[FIX] website_event_crm: another company's event

### DIFF
--- a/crm_event/tests/test_event_type.py
+++ b/crm_event/tests/test_event_type.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from odoo.tests.common import SavepointCase
 
 
-class EventTypeCase(SavepointCase):
+class CrmEventCase(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -94,6 +94,8 @@ class EventTypeCase(SavepointCase):
         for opp in cls.opportunities:
             cls.leads |= opp.copy({"type": "lead"})
 
+
+class CrmEventTest(CrmEventCase):
     def test_event_totals(self):
         self.assertEqual(self.type_a.seats_available_total, "3 (1101)")
         self.assertEqual(self.type_b.seats_available_total, "3 (Unlimited)")

--- a/website_event_crm/data/mail_template_data.xml
+++ b/website_event_crm/data/mail_template_data.xml
@@ -28,7 +28,7 @@
                 <p>
                     <div style="margin: 16px 8px 16px 8px; text-align: center;">
                         <a
-                            href="${object.event_type_website_url}"
+                            href="${ctx.get('base_url', '')}${object.event_type_website_url}"
                             style="background-color: #875a7b; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px;"
                         >
                             View events of category

--- a/website_event_crm/tests/__init__.py
+++ b/website_event_crm/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_website_event_crm

--- a/website_event_crm/tests/test_website_event_crm.py
+++ b/website_event_crm/tests/test_website_event_crm.py
@@ -1,0 +1,72 @@
+# Copyright 2022 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.fields import first
+
+from odoo.addons.crm_event.tests.test_event_type import CrmEventCase
+
+
+class WebsiteEventCrmTests(CrmEventCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_2 = cls.env["res.company"].create({"name": "Test Company 2"})
+        cls.website_1 = cls.env["website"].create(
+            {"name": "Test WWW 1", "domain": "www.test-www-1.test"}
+        )
+        cls.website_2 = cls.env["website"].create(
+            {"name": "Test WWW 2", "domain": "www.test-www-2.test"}
+        )
+        cls.a_events.website_id = cls.website_1
+        cls.b_events.website_id = cls.website_2
+        cls.invite_stage = cls.env["crm.stage"].create(
+            {"name": "Test Pending", "auto_invite_website_event_type": True}
+        )
+        # An opportunity which we'll should be invited to the event
+        cls.opportunity_1 = first(cls.opportunities).copy(
+            {"email_from": "test@test.com", "stage_id": cls.invite_stage.id}
+        )
+        # An opportunity from another company wich won't get any invitation
+        cls.opportunity_2 = first(cls.opportunities).copy(
+            {
+                "email_from": "test@test.com",
+                "stage_id": cls.invite_stage.id,
+                "company_id": cls.company_2.id,
+            }
+        )
+        # An opportunity from antother type
+        cls.opportunity_3 = first(cls.opportunities).copy(
+            {
+                "email_from": "test@test.com",
+                "stage_id": cls.invite_stage.id,
+                "event_type_id": cls.type_b.id,
+            }
+        )
+        # An opportunity on a stage without auto invite
+        cls.opportunity_4 = first(cls.opportunities).copy(
+            {"email_from": "test@test.com"}
+        )
+
+    def _lead_msg(self, lead):
+        return "\n".join(lead.message_ids.mapped("body"))
+
+    def _test_event_type_invitation(self, lead):
+        return "/event?type={}".format(lead.event_type_id.id) in self._lead_msg(lead)
+
+    def test_event_crm_invite_cron(self):
+        self.a_events.website_published = True
+        # No invitation until cron is run
+        self.assertFalse(self._test_event_type_invitation(self.opportunity_1))
+        self.assertFalse(self._test_event_type_invitation(self.opportunity_2))
+        self.assertFalse(self._test_event_type_invitation(self.opportunity_3))
+        self.assertFalse(self._test_event_type_invitation(self.opportunity_4))
+        self.env["crm.lead"]._cron_auto_invite_website_event_type()
+        # Opportunity 1 event category has published events available
+        self.assertTrue(self._test_event_type_invitation(self.opportunity_1))
+        # We also get the right base url
+        self.assertTrue(self.website_1.domain in self._lead_msg(self.opportunity_1))
+        # Opportunity 2 is from another company. It should not receive a notification
+        self.assertFalse(self._test_event_type_invitation(self.opportunity_2))
+        # The type of opportunity 3 doesn't have event available
+        self.assertFalse(self._test_event_type_invitation(self.opportunity_3))
+        # Opportunity 4 is in a stage with no auto invitation mail
+        self.assertFalse(self._test_event_type_invitation(self.opportunity_4))

--- a/website_event_crm/views/crm_lead_view.xml
+++ b/website_event_crm/views/crm_lead_view.xml
@@ -9,13 +9,25 @@
         <field name="arch" type="xml">
             <header>
                 <field name="event_type_website_url" invisible="1" />
+                <field name="auto_invite_warning" invisible="1" />
                 <button
                     string="Invite to website"
                     name="action_invite_to_website_event_type"
                     type="object"
-                    attrs="{'invisible': [('event_type_website_url', '=', False)]}"
+                    attrs="{'invisible': ['|', ('event_type_website_url', '=', False), ('auto_invite_warning', '=', True)]}"
                 />
             </header>
+            <xpath expr="//div[hasclass('oe_title')]" position="before">
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': [('auto_invite_warning', '=', False)]}"
+                >
+                    <i
+                        class="fa fa-info"
+                    /> It's not possible to determine to propose events if the company isn't set or if the company has no websites. So no invitation will be sent for this lead
+                </div>
+            </xpath>
         </field>
     </record>
 </data>


### PR DESCRIPTION
The company field isn't mandatory for event types, so we have to check that a lead auto invites to events available in the company of the lead.

- [x] Ensure sending company wise invitations to events.
- [x] Ensure right base_url for the sent link
- [x] Disengaged `crm_event` test data declaration for easy  reuse
- [x] Regression tests


cc @Tecnativa TT36027

please review @victoralmau @pedrobaeza 