### PR TITLE
[15.0] [MIG] `event_sale_reserve_registration`: Migration to 15.0

### DIFF
--- a/event_sale_reserve_registration/__init__.py
+++ b/event_sale_reserve_registration/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/event_sale_reserve_registration/__manifest__.py
+++ b/event_sale_reserve_registration/__manifest__.py
@@ -4,7 +4,7 @@
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Marketing/Events",
-    "website": "https://www.odoo.com/page/events",
+    "website": "https://github.com/OCA/event",
     "summary": "Allow to reserve registrations before confirming sale order",
     "depends": ["event_sale_attendees"],
     "data": ["views/sale_view.xml"],

--- a/event_sale_reserve_registration/__manifest__.py
+++ b/event_sale_reserve_registration/__manifest__.py
@@ -1,12 +1,12 @@
 {
     "name": "Events Sale Reserve Registrations",
-    "version": "13.0.1.0.0",
+    "version": "15.0.1.0.0",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Marketing/Events",
     "website": "https://github.com/OCA/event",
     "summary": "Allow to reserve registrations before confirming sale order",
-    "depends": ["event_sale_attendees"],
+    "depends": ["event_sale"],
     "data": ["views/sale_view.xml"],
     "installable": True,
 }

--- a/event_sale_reserve_registration/__manifest__.py
+++ b/event_sale_reserve_registration/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "Events Sale Reserve Registrations",
+    "version": "13.0.1.0.0",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "Marketing/Events",
+    "website": "https://www.odoo.com/page/events",
+    "summary": "Allow to reserve registrations before confirming sale order",
+    "depends": ["event_sale_attendees"],
+    "data": ["views/sale_view.xml"],
+    "installable": True,
+}

--- a/event_sale_reserve_registration/models/__init__.py
+++ b/event_sale_reserve_registration/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/event_sale_reserve_registration/models/sale_order.py
+++ b/event_sale_reserve_registration/models/sale_order.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def update_event_registrations(self):
+        for order in self:
+            order.order_line._update_registrations(
+                confirm=False, cancel_to_draft=False, registration_data=None
+            )
+
+        return True
+
+    def confirm_event_registrations(self):
+        for sale in self:
+            sale.order_line._update_registrations(confirm=True, cancel_to_draft=False)

--- a/event_sale_reserve_registration/readme/CONTRIBUTORS.rst
+++ b/event_sale_reserve_registration/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp SA <https://www.camptocamp.com>`__:
+
+   * Damien Crier

--- a/event_sale_reserve_registration/readme/DESCRIPTION.rst
+++ b/event_sale_reserve_registration/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module allows to create event attendees (in draft) when sale order is in "draft" state.
+You can confirm registration of attendees from the sale order.

--- a/event_sale_reserve_registration/views/sale_view.xml
+++ b/event_sale_reserve_registration/views/sale_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2021 Camptocamp SA
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+-->
+<odoo>
+    <record id="sale_order_view_form" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.event.sale</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <button name="action_draft" position="after">
+                <button
+                    name="update_event_registrations"
+                    type="object"
+                    string="Reserve attendees"
+                />
+                <button
+                    name="confirm_event_registrations"
+                    type="object"
+                    string="Confirm attendees"
+                />
+            </button>
+        </field>
+    </record>
+</odoo>

--- a/setup/event_sale_reserve_registration/odoo/addons/event_sale_reserve_registration
+++ b/setup/event_sale_reserve_registration/odoo/addons/event_sale_reserve_registration
@@ -1,0 +1,1 @@
+../../../../event_sale_reserve_registration

--- a/setup/event_sale_reserve_registration/setup.py
+++ b/setup/event_sale_reserve_registration/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Migration of `event_sale_reserve_registration` module from v13  (from [this pr](https://github.com/OCA/event/pull/228)) to v15