### PR TITLE
[14.0][FIX] event_session: Refactor generate_sessions_button_visible 

### DIFF
--- a/event_session/models/event.py
+++ b/event_session/models/event.py
@@ -39,7 +39,7 @@ class EventEvent(models.Model):
         string=" # No of Confirmed Registrations",
         store=True,
     )
-    generate_sessions_button_visible = fields.Boolean(related="stage_id.pipe_end")
+    generate_sessions_button_hide = fields.Boolean(related="stage_id.pipe_end")
 
     @api.depends("session_ids")
     def _compute_sessions_count(self):

--- a/event_session/wizards/wizard_event_session_view.xml
+++ b/event_session/wizards/wizard_event_session_view.xml
@@ -12,12 +12,12 @@
         <field name="inherit_id" ref="event.view_event_form" />
         <field name="arch" type="xml">
             <field name="stage_id" position="before">
-                <field name="generate_sessions_button_visible" invisible="1" />
+                <field name="generate_sessions_button_hide" invisible="1" />
                 <button
                     string="Generate Sessions"
                     name="%(act_wizard_event_session)d"
                     type="action"
-                    attrs="{'invisible': [('generate_sessions_button_visible', '=', False)]}"
+                    attrs="{'invisible': [('generate_sessions_button_hide', '=', True)]}"
                 />
             </field>
         </field>


### PR DESCRIPTION
cc @Tecnativa TT43956

Refactor `generate_sessions_button_visible` field to `generate_sessions_button_hide` .  The button for generation sessions was being hide when the event wasn't ended. This fix corrects the functionality and renames the field in a more consistent way according to it's function.

@chienandalu please review!