### PR TITLE
[15.0] [ADD] Add module `website_event_sale_joined_constraint`

### DIFF
--- a/setup/website_event_sale_joined_constraint/odoo/addons/website_event_sale_joined_constraint
+++ b/setup/website_event_sale_joined_constraint/odoo/addons/website_event_sale_joined_constraint
@@ -1,0 +1,1 @@
+../../../../website_event_sale_joined_constraint

--- a/setup/website_event_sale_joined_constraint/setup.py
+++ b/setup/website_event_sale_joined_constraint/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/website_event_sale_joined_constraint/__init__.py
+++ b/website_event_sale_joined_constraint/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/website_event_sale_joined_constraint/__manifest__.py
+++ b/website_event_sale_joined_constraint/__manifest__.py
@@ -1,0 +1,29 @@
+# Copyright 2023 Camptocamp (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+{
+    "name": "Website Event Sale Joined Constraint",
+    "summary": "Allow to add constraints on event ticket sold on the website",
+    "version": "15.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Website/Website",
+    "website": "https://github.com/OCA/event",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "website_event_sale",
+    ],
+    "data": [
+        # Views
+        "views/event_templates_page_registration.xml",
+        "views/event_ticket_views.xml",
+        "views/product_views.xml",
+    ],
+    "assets": {
+        "web.assets_frontend": [
+            "website_event_sale_joined_constraint/static/src/js"
+            "/website_event_ticket_details.js",
+        ],
+    },
+}

--- a/website_event_sale_joined_constraint/controllers/__init__.py
+++ b/website_event_sale_joined_constraint/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import website_event_sale_joined_constraint_controller

--- a/website_event_sale_joined_constraint/controllers/website_event_sale_joined_constraint_controller.py
+++ b/website_event_sale_joined_constraint/controllers/website_event_sale_joined_constraint_controller.py
@@ -1,0 +1,28 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import http
+
+from odoo.addons.website_event_sale.controllers.main import WebsiteEventSaleController
+
+
+class WebsiteEventSaleJoinedConstraintController(WebsiteEventSaleController):
+    @http.route()
+    def registration_new(self, event, **post):
+        tickets = self._process_tickets_form(event, post)
+        if self._only_child_tickets_sold(tickets):
+            return False
+        return super().registration_new(event, **post)
+
+    def _process_tickets_form(self, event, form_details):
+        """Add constraints information on ticket order"""
+        res = super(WebsiteEventSaleController, self)._process_tickets_form(
+            event, form_details
+        )
+        for item in res:
+            item["is_child"] = (
+                item["ticket"]["is_child_ticket"] if item["ticket"] else False
+            )
+        return res
+
+    def _only_child_tickets_sold(self, tickets):
+        return all([ticket["is_child"] for ticket in tickets])

--- a/website_event_sale_joined_constraint/models/__init__.py
+++ b/website_event_sale_joined_constraint/models/__init__.py
@@ -1,0 +1,4 @@
+from . import event_event_ticket
+from . import product
+from . import sale_order
+from . import website

--- a/website_event_sale_joined_constraint/models/event_event_ticket.py
+++ b/website_event_sale_joined_constraint/models/event_event_ticket.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class EventTicket(models.Model):
+    _inherit = "event.event.ticket"
+
+    is_child_ticket = fields.Boolean(related="product_id.is_child_ticket")

--- a/website_event_sale_joined_constraint/models/product.py
+++ b/website_event_sale_joined_constraint/models/product.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class Product(models.Model):
+    _inherit = "product.template"
+
+    is_child_ticket = fields.Boolean(
+        help="Child tickets can't be bought on website without buying a non child one."
+    )

--- a/website_event_sale_joined_constraint/models/sale_order.py
+++ b/website_event_sale_joined_constraint/models/sale_order.py
@@ -1,0 +1,52 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _cart_update(
+        self, product_id=None, line_id=None, add_qty=0, set_qty=0, **kwargs
+    ):
+        # Add a check to ensure the last parent ticket is not removed from cart
+        # if there are remaining child tickets
+        if add_qty or not line_id:
+            return super()._cart_update(product_id, line_id, add_qty, set_qty, **kwargs)
+        try:
+            new_qty = float(set_qty)
+        except ValueError:
+            new_qty = -1
+        line = self.env["sale.order.line"].browse(line_id)
+        ticket = line.event_ticket_id
+
+        if ticket and not ticket.is_child_ticket and new_qty == 0:
+            # When removing a parent ticket, we need to check that no child ticket is
+            # left alone, ie. there is no left child ticket, or there is at least one
+            # other parent ticket.
+            remaining_child_ticket_lines = self.order_line.filtered_domain(
+                [
+                    ("event_ticket_id.is_child_ticket", "=", True),
+                    ("product_uom_qty", ">", 0),
+                    ("event_id", "=", ticket.event_id.id),
+                ]
+            )
+            remaining_parent_tickets_lines = self.order_line.filtered_domain(
+                [
+                    ("event_ticket_id.is_child_ticket", "=", False),
+                    ("product_uom_qty", ">", 0),
+                    ("id", "!=", line_id),
+                    ("event_id", "=", ticket.event_id.id),
+                ]
+            )
+            if remaining_child_ticket_lines and not remaining_parent_tickets_lines:
+                values = {
+                    "warning": self.env["website"]
+                    .get_current_website()
+                    .website_event_sale_constraint_message,
+                    "line_id": line_id,
+                    "quantity": line.product_uom_qty,  # Former quantity
+                }
+                return values
+
+        return super()._cart_update(product_id, line_id, add_qty, set_qty, **kwargs)

--- a/website_event_sale_joined_constraint/models/website.py
+++ b/website_event_sale_joined_constraint/models/website.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class Website(models.Model):
+    _inherit = "website"
+
+    website_event_sale_constraint_message = fields.Text(
+        default="Please add at least one parent ticket to be able to register.",
+    )

--- a/website_event_sale_joined_constraint/readme/CONFIGURE.rst
+++ b/website_event_sale_joined_constraint/readme/CONFIGURE.rst
@@ -1,0 +1,3 @@
+Go to a Product > Set product type = Event ticket > Tick "Is a child ticket" right above
+
+Child tickets can't be sold on website without a non-child ticket.

--- a/website_event_sale_joined_constraint/readme/CONTRIBUTORS.rst
+++ b/website_event_sale_joined_constraint/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+     * Camille Morand <camille.morand@camptocamp.com>

--- a/website_event_sale_joined_constraint/readme/DESCRIPTION.rst
+++ b/website_event_sale_joined_constraint/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Allows to prevent website customer to buy specific tickets alone, without buying another type of tickets.

--- a/website_event_sale_joined_constraint/static/src/js/website_event_ticket_details.js
+++ b/website_event_sale_joined_constraint/static/src/js/website_event_ticket_details.js
@@ -1,0 +1,55 @@
+// Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+// License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+odoo.define("website_event_sale_joined_constraint.ticket_details", function (require) {
+    "use strict";
+
+    const ticketDetailsWidget = require("website_event.ticket_details");
+
+    ticketDetailsWidget.include({
+        // --------------------------------------------------------------------------
+        // Private
+        // --------------------------------------------------------------------------
+
+        /**
+         * @private
+         * @returns {integer} Number of selected parent tickets
+         */
+        _getParentTicketCount: function () {
+            var ticketCount = 0;
+            this.$(".parent_ticket_select").each(function () {
+                ticketCount += parseInt($(this).val(), 10);
+            });
+            return ticketCount;
+        },
+
+        /**
+         * @private
+         * @returns {integer} Number of selected child tickets
+         */
+        _getChildTicketCount: function () {
+            var ticketCount = 0;
+            this.$(".child_ticket_select").each(function () {
+                ticketCount += parseInt($(this).val(), 10);
+            });
+            return ticketCount;
+        },
+
+        // --------------------------------------------------------------------------
+        // Handlers
+        // --------------------------------------------------------------------------
+        /**
+         * @override
+         */
+        _onTicketQuantityChange: function () {
+            this._super.apply(this, arguments);
+            const parents_count = this._getParentTicketCount();
+            const children_count = this._getChildTicketCount();
+            this.$("button.btn-primary").attr("disabled", parents_count === 0);
+            this.$(".event_sale_constraint_message").attr(
+                "hidden",
+                parents_count !== 0 || children_count === 0
+            );
+        },
+    });
+});

--- a/website_event_sale_joined_constraint/views/event_templates_page_registration.xml
+++ b/website_event_sale_joined_constraint/views/event_templates_page_registration.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Camptocamp SA (https://www.camptocamp.com).-->
+<!-- License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).-->
+<odoo>
+    <!-- Event - Registration -->
+    <template
+        id="registration_template"
+        inherit_id="website_event.registration_template"
+    >
+        <!-- Adding new class on displayed tickets -->
+        <xpath expr="//select[hasclass('custom-select')]" position="attributes">
+            <attribute
+                name="t-attf-class"
+            >custom-select {{ticket.is_child_ticket and 'child_ticket_select' or 'parent_ticket_select'}}</attribute>
+        </xpath>
+        <xpath
+            expr="//select[hasclass('w-auto','custom-select')]"
+            position="attributes"
+        >
+            <attribute
+                name="t-attf-class"
+            >w-auto custom-select {{tickets.is_child_ticket and 'child_ticket_select' or 'parent_ticket_select'}}</attribute>
+        </xpath>
+        <!-- Adding explanation message -->
+        <div t-foreach="tickets" position="after">
+            <div class="text-right p-2 event_sale_constraint_message" hidden="True">
+                <em
+                    class="text-info"
+                    t-field="website.website_event_sale_constraint_message"
+                />
+            </div>
+        </div>
+        <xpath
+            expr="//div[hasclass('o_wevent_registration_single')]/div/div[1]"
+            position="after"
+        >
+            <div class="text-right p-2 event_sale_constraint_message" hidden="True">
+                <em
+                    class="text-info"
+                    t-field="website.website_event_sale_constraint_message"
+                />
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/website_event_sale_joined_constraint/views/event_ticket_views.xml
+++ b/website_event_sale_joined_constraint/views/event_ticket_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2023 Camptocamp SA (https://www.camptocamp.com).-->
+<!-- License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).-->
+<odoo>
+    <record id="event_event_ticket_view_tree_from_event" model="ir.ui.view">
+        <field name="model">event.event.ticket</field>
+        <field
+            name="inherit_id"
+            ref="event_sale.event_event_ticket_view_tree_from_event"
+        />
+        <field name="arch" type="xml">
+                <field name="price" position="after">
+                    <field name="is_child_ticket" />
+                </field>
+        </field>
+    </record>
+</odoo>

--- a/website_event_sale_joined_constraint/views/product_views.xml
+++ b/website_event_sale_joined_constraint/views/product_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Camptocamp SA (https://www.camptocamp.com).-->
+<!-- License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).-->
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='detailed_type']" position="after">
+                <field
+                    name="is_child_ticket"
+                    string="Is a child ticket"
+                    attrs="{'invisible': [('detailed_type', '!=', 'event')]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module allows to prevent website customer to buy specific tickets alone, without buying another type of tickets.

https://github.com/OCA/event/assets/43339411/e32e7bdd-7763-4a23-aa7b-54c5dd00eb57