### PR TITLE
[15.0] [FIX] event_session: regular event mail schedulers

### DIFF
--- a/event_session/models/event_registration.py
+++ b/event_session/models/event_registration.py
@@ -59,10 +59,11 @@ class EventRegistration(models.Model):
         # OVERRIDE to handle sessions' mail scheduler, not event ones.
         session_records = self.filtered("session_id")
         regular_records = self - session_records
+        res = super(EventRegistration, regular_records)._update_mail_schedulers()
         # Similar to super, only we find the schedulers linked to the session
-        open_registrations = self.filtered(lambda r: r.state == "open")
+        open_registrations = session_records.filtered(lambda r: r.state == "open")
         if not open_registrations:
-            return
+            return res
         onsubscribe_schedulers = (
             self.env["event.mail.session"]
             .sudo()
@@ -74,7 +75,7 @@ class EventRegistration(models.Model):
             )
         )
         if not onsubscribe_schedulers:
-            return
+            return res
         onsubscribe_schedulers.mail_done = False
         onsubscribe_schedulers.with_user(SUPERUSER_ID).execute()
-        return super(EventRegistration, regular_records)._update_mail_schedulers()
+        return res


### PR DESCRIPTION
This override wasn't done properly and thus it wasn't calling super for non-session events.


Closes https://github.com/OCA/event/issues/313
