### PR TITLE
[15.0][FIX-IMP] website_event_sale_b2x_alt_price: correct vertical alignment

### DIFF
--- a/website_event_sale_b2x_alt_price/templates/website_event_sale.xml
+++ b/website_event_sale_b2x_alt_price/templates/website_event_sale.xml
@@ -40,7 +40,12 @@
             expr="//div[hasclass('o_wevent_registration_single')]//t[@t-if='tickets.price']/.."
             position="attributes"
         >
-            <attribute name="class" separator=" " add="flex-column" />
+            <attribute
+                name="class"
+                separator=" "
+                add="flex-column"
+                remove="align-self-stretch"
+            />
         </xpath>
     </template>
 


### PR DESCRIPTION
When the module is installed and the price is not taxed, as it also adds the flex-column class vertically it tries to occupy the full height of the container and rises to the top instead of being vertically centred. Removing the align-self-stretch class avoids this behaviour.

cc @Tecnativa TT44699

Before:

![image](https://github.com/OCA/event/assets/118818446/af3a1854-a41e-42e5-903e-7dc5103b3b84)

After:
![image](https://github.com/OCA/event/assets/118818446/7074ecbf-745e-44cd-8608-caf98b2db9f5)

@chienandalu @CarlosRoca13  please review :)