### PR TITLE
[15.0][IMP] partner_event: Do registration creation in batch + remove savepoint

### DIFF
--- a/partner_event/models/event_registration.py
+++ b/partner_event/models/event_registration.py
@@ -1,8 +1,8 @@
-# Copyright 2014 Tecnativa S.L. - Pedro M. Baeza
-# Copyright 2015 Tecnativa S.L. - Javier Iniesta
-# Copyright 2016 Tecnativa S.L. - Antonio Espinosa
-# Copyright 2016 Tecnativa S.L. - Vicent Cubells
-# Copyright 2020 Tecnativa S.L. - Víctor Martínez
+# Copyright 2015 Tecnativa - Javier Iniesta
+# Copyright 2016 Tecnativa - Antonio Espinosa
+# Copyright 2016 Tecnativa - Vicent Cubells
+# Copyright 2020 Tecnativa - Víctor Martínez
+# Copyright 2014-2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
@@ -17,6 +17,7 @@ class EventRegistration(models.Model):
         string="Attendee Partner",
         ondelete="restrict",
         copy=False,
+        index=True,
     )
 
     def _prepare_partner(self, vals):

--- a/partner_event/wizard/res_partner_register_event.py
+++ b/partner_event/wizard/res_partner_register_event.py
@@ -1,9 +1,9 @@
-# Copyright 2014 Tecnativa S.L. - Pedro M. Baeza
-# Copyright 2015 Tecnativa S.L. - Javier Iniesta
-# Copyright 2016 Tecnativa S.L. - Antonio Espinosa
-# Copyright 2016 Tecnativa S.L. - Vicent Cubells
+# Copyright 2015 Tecnativa - Javier Iniesta
+# Copyright 2016 Tecnativa - Antonio Espinosa
+# Copyright 2016 Tecnativa - Vicent Cubells
 # Copyright 2018 Jupical Technologies Pvt. Ltd. - Anil Kesariya
-# Copyright 2020 Tecnativa S.L. - Víctor Martínez
+# Copyright 2020 Tecnativa - Víctor Martínez
+# Copyright 2014-2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
@@ -11,13 +11,11 @@ from odoo import fields, models
 
 class ResPartnerRegisterEvent(models.TransientModel):
     _name = "res.partner.register.event"
-
     _description = "Register partner for event"
 
     event = fields.Many2one(
         comodel_name="event.event", required=True, ondelete="cascade"
     )
-    errors = fields.Text(readonly=True)
 
     def _prepare_registration(self, partner):
         return {
@@ -31,24 +29,16 @@ class ResPartnerRegisterEvent(models.TransientModel):
         }
 
     def button_register(self):
-        registration_obj = self.env["event.registration"]
-        errors = []
+        vals_list = []
+        Registration = self.env["event.registration"]
         for partner in self.env["res.partner"].browse(
             self.env.context.get("active_ids", [])
         ):
-            try:
-                with self.env.cr.savepoint():
-                    registration_obj.create(self._prepare_registration(partner))
-            except Exception:
-                errors.append(partner.name)
-        if errors:
-            self.errors = "\n".join(errors)
-            data_obj = self.env.ref("partner_event." "res_partner_register_event_view")
-            return {
-                "type": "ir.actions.act_window",
-                "res_model": self._name,
-                "view_mode": "form",
-                "view_id": [data_obj.id],
-                "res_id": self.id,
-                "target": "new",
-            }
+            if not Registration.search(
+                [
+                    ("event_id", "=", self.event.id),
+                    ("attendee_partner_id", "=", partner.id),
+                ]
+            ):
+                vals_list.append(self._prepare_registration(partner))
+        self.env["event.registration"].create(vals_list)

--- a/partner_event/wizard/res_partner_register_event_view.xml
+++ b/partner_event/wizard/res_partner_register_event_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright 2016 Tecnativa S.L. - Vicent Cubells
+<!-- Copyright 2016 Tecnativa - Vicent Cubells
+     Copyright 2023 Tecnativa - Pedro M. Baeza
      Copyright 2018 Jupical Technologies Pvt. Ltd. - Anil kesariya
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
 <odoo>
@@ -8,22 +9,14 @@
         <field name="model">res.partner.register.event</field>
         <field name="arch" type="xml">
             <form string="Select event to register">
-                <group attrs="{'invisible': [('errors', '!=', False)]}">
+                <group>
                     <field
                         name="event"
                         options="{'no_create': True, 'no_create_edit':True}"
                     />
                 </group>
-                <group attrs="{'invisible': [('errors', '=', False)]}">
-                    <separator
-                        colspan="4"
-                        string="These partners haven't been registered because they\'re already
-                       registered or other error occurred"
-                    />
-                    <field nolabel="1" name="errors" colspan="4" />
-                </group>
                 <footer>
-                    <div attrs="{'invisible': [('errors', '!=', False)]}">
+                    <div>
                         <button
                             name="button_register"
                             type="object"


### PR DESCRIPTION
For speeding up the process. Specially the removal of the savepoints makes that Postgres don't go slow as hell. Check https://www.cybertec-postgresql.com/en/subtransactions-and-performance-in-postgresql/ for some rationale. The problem happens even releasing the previous savepoints.

As this module is very old, the reason for doing it this way and skip registrations with error is not fully known, but the view mentions about registration duplication, so let's avoid it and handle later other possible exceptions.

@Tecnativa TT26694