### PR TITLE
[15.0][FIX] partner_event: NewId compatibility

### DIFF
--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -27,7 +27,7 @@ class ResPartner(models.Model):
                 self.env["event.registration"]
                 .search(
                     [
-                        ("attendee_partner_id", "child_of", partner.id),
+                        ("attendee_partner_id", "child_of", partner.ids),
                         ("state", "not in", ("cancel", "draft")),
                     ]
                 )


### PR DESCRIPTION
When the compute is triggered from a NewId the domain will fail when it's evaluated as expression parser can't deal with it.

cc @Tecnativa TT45858

please review @victoralmau @pedrobaeza 