### PR TITLE
[16.0][FIX] partner_event: Don't update attendee_partner_id merging partners

### DIFF
--- a/partner_event/models/event_registration.py
+++ b/partner_event/models/event_registration.py
@@ -29,7 +29,12 @@ class EventRegistration(models.Model):
         }
 
     def _update_attendee_partner_id(self, vals):
-        if not vals.get("attendee_partner_id") and vals.get("email"):
+        # Don't update if doing a partner merging
+        if (
+            not vals.get("attendee_partner_id")
+            and vals.get("email")
+            and not self.env.context.get("partner_event_merging")
+        ):
             Partner = self.env["res.partner"]
             Event = self.env["event.event"]
             # Look for a partner with that email

--- a/partner_event/wizard/__init__.py
+++ b/partner_event/wizard/__init__.py
@@ -1,1 +1,2 @@
+from . import base_partner_merge_automatic_wizard
 from . import res_partner_register_event

--- a/partner_event/wizard/base_partner_merge_automatic_wizard.py
+++ b/partner_event/wizard/base_partner_merge_automatic_wizard.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class BasePartnerMergeAutomaticWizard(models.TransientModel):
+    _inherit = "base.partner.merge.automatic.wizard"
+
+    def action_merge(self):
+        """Inject context for later intercept it when the merge process does a flush,
+        and an update is launched on the partner that recomputes attendee_partner_id.
+        """
+        self = self.with_context(partner_event_merging=True)
+        return super().action_merge()


### PR DESCRIPTION
Forward-port of #354
No needed changes, as both the wizard remains the same and the update method remains the same.

Steps to reproduce:

- Have several partners with the same email.
- Generate an event registration for each of the partners.
- Launch the contact merge wizard.
- Select the destination contact the one with the name that is alphabetically later.
- Launch the merge.

Current behavior:

Model: Event Registration (event.registration), Constraint: event_registration_attendee_partner_id_fkey

ERROR: update or delete on table "res_partner" violates foreign key constraint "event_registration_attendee_partner_id_fkey" on table "event_registration"
DETAIL:  Key (id)=(NNN) is still referenced from table "event_registration"

Expected behavior:

Successful merge.

The problem arises when ORM launches a flush before unlinking partners. Such recomputation launches a write on existing event registration records, which calls the update of the attendee_partner_id.

To prevent it, we just skip such process if performing the merge.

@Tecnativa TT46798