### PR TITLE
[16.0][IMP] event_session: improve UX in session tree

### DIFF
--- a/event_session/views/event_session.xml
+++ b/event_session/views/event_session.xml
@@ -248,10 +248,11 @@
         <field name="model">event.session</field>
         <field name="arch" type="xml">
             <tree>
-                <field name="event_id" />
+                <field name="event_id" optional="show" />
                 <field name="date_begin" />
                 <field name="date_end" />
-                <field name="date_tz" />
+                <field name="date_tz" optional="hide" />
+                <field name="seats_limited" optional="hide" />
                 <field
                     name="seats_expected"
                     string="Expected Attendees"


### PR DESCRIPTION
- Hide tz: if our events are always in the same tz, it can be quite useless.
- Optionally display: event_id (known if you access from the button in the event)
- Add (hidden) the seats limited flag

please review @pedrobaeza @victoralmau 

cc @Tecnativa TT46031