### PR TITLE
[16.0][FIX] event_session: Change web_ribbon text to title to make it translatable

### DIFF
--- a/event_session/views/event_session.xml
+++ b/event_session/views/event_session.xml
@@ -147,7 +147,7 @@
                     <field name="active" invisible="1" />
                     <widget
                         name="web_ribbon"
-                        text="Archived"
+                        title="Archived"
                         bg_color="bg-danger"
                         attrs="{'invisible': [('active', '=', True)]}"
                     />


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/event/pull/358

Change web_ribbon text to title to make it translatable

@Tecnativa