### PR TITLE
[16.0][FIX] event_mail: Fix Mail Scheduler view

### DIFF
--- a/event_mail/views/event_mail_view.xml
+++ b/event_mail/views/event_mail_view.xml
@@ -12,7 +12,7 @@
                         <field name="name" />
                     </group>
                     <group string="Mail Scheduler">
-                        <field name="scheduler_template_ids" nolabel="1">
+                        <field name="scheduler_template_ids" nolabel="1" colspan="2">
                             <tree editable="bottom">
                                 <field name="sequence" widget="handle" />
                                 <field name="template_ref" />


### PR DESCRIPTION
- When accessing to Mail Scheduler view, one2many field appears in this way:

<img width="803" alt="image" src="https://github.com/OCA/event/assets/143796894/fa644f78-6ead-4d7b-9e2b-ed133b7e2f9f">

- This PR fixes the view:
![image](https://github.com/OCA/event/assets/143796894/1eb68ac0-d876-4b5a-b3f6-4142c3c790a3)


TT46031

@Tecnativa
@pedrobaeza @sergio-teruel 