### PR TITLE
[16.0][FIX] event_session: event global number of attendees

### DIFF
--- a/event_session/views/event_event.xml
+++ b/event_session/views/event_event.xml
@@ -89,16 +89,6 @@
                 <field name="use_sessions" />
                 <field name="session_count" />
             </templates>
-            <xpath
-                expr="//templates//a[@name='%(event.event_registration_action_stats_from_event)d']/parent::*"
-                position="attributes"
-            >
-                <attribute name="attrs">
-                    {
-                        'invisible': [('use_sessions', '=', True)],
-                    }
-                </attribute>
-            </xpath>
             <div class="o_kanban_record_bottom" position="before">
                 <h5
                     name="sessions"


### PR DESCRIPTION
The globla number of attendees and its link is a value that doesn't misslead users. They will step right into the event attendees report where they group by session and have a global view of the event performance by attendees.

cc @Tecnativa TT49352

please review @carolinafernandez-tecnativa 

fyi @ivantodorovich 