### PR TITLE
[15.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/event_quick_registration/__manifest__.py
+++ b/event_quick_registration/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Event Quick Registration",
     "summary": "Create registration quickly",
     "version": "15.0.1.0.0",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/event",
     "category": "Event",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 15.0.