### PR TITLE
[FIX] partner_event: get chosen partner even if not contact

### DIFF
--- a/partner_event/README.rst
+++ b/partner_event/README.rst
@@ -112,6 +112,17 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-yajo| image:: https://github.com/yajo.png?size=40px
+    :target: https://github.com/yajo
+    :alt: yajo
+.. |maintainer-rafaelbn| image:: https://github.com/rafaelbn.png?size=40px
+    :target: https://github.com/rafaelbn
+    :alt: rafaelbn
+
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-yajo| |maintainer-rafaelbn| 
+
 This module is part of the `OCA/event <https://github.com/OCA/event/tree/16.0/partner_event>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/partner_event/__manifest__.py
+++ b/partner_event/__manifest__.py
@@ -24,6 +24,7 @@
         "views/event_registration_view.xml",
         "wizard/res_partner_register_event_view.xml",
     ],
+    "maintainers": ["yajo", "rafaelbn"],
     "post_init_hook": "post_init_hook",
     "installable": True,
 }

--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -42,5 +42,5 @@ class ResPartner(models.Model):
     def address_get(self, adr_pref=None):
         attendee_partner = self.env.context.get("get_attendee_partner_address", False)
         if attendee_partner:
-            return super(ResPartner, attendee_partner).address_get(adr_pref)
+            return {adr_pref: attendee_partner}
         return super(ResPartner, self).address_get(adr_pref)

--- a/partner_event/static/description/index.html
+++ b/partner_event/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -446,10 +447,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/yajo"><img alt="yajo" src="https://github.com/yajo.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/rafaelbn"><img alt="rafaelbn" src="https://github.com/rafaelbn.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/event/tree/16.0/partner_event">OCA/event</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
1. Create a partner that has a parent company.
2. Set it as "other" kind of address.
3. Create an event registration, selecting that partner as attendee partner.
4. The module was filling the contact details from the company, and not from the partner.

@moduon MT-7901