### PR TITLE
[17.0][FIX] website_event_filter_city: Country filter support

### DIFF
--- a/website_event_filter_city/README.rst
+++ b/website_event_filter_city/README.rst
@@ -48,8 +48,8 @@ To configure this module, you need to:
 Known issues / Roadmap
 ======================
 
-- You cannot run the tests unless you are in a bare database with demo
-  data.
+-  You cannot run the tests unless you are in a bare database with demo
+   data.
 
 Bug Tracker
 ===========
@@ -74,18 +74,18 @@ Authors
 Contributors
 ------------
 
-- Dennis Sluijk <d.sluijk@onestein.nl>
+-  Dennis Sluijk <d.sluijk@onestein.nl>
 
-- Cristina Martin R.
+-  Cristina Martin R.
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-     - Rafael Blasco
-     - Pedro Baeza
-     - Jairo Llopis
-     - Víctor Martínez
-     - David Vidal
-     - Pilar Vargas
+      -  Rafael Blasco
+      -  Pedro Baeza
+      -  Jairo Llopis
+      -  Víctor Martínez
+      -  David Vidal
+      -  Pilar Vargas
 
 Maintainers
 -----------
@@ -100,13 +100,13 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-.. |maintainer-Yajo| image:: https://github.com/Yajo.png?size=40px
-    :target: https://github.com/Yajo
-    :alt: Yajo
+.. |maintainer-pilarvargas-tecnativa| image:: https://github.com/pilarvargas-tecnativa.png?size=40px
+    :target: https://github.com/pilarvargas-tecnativa
+    :alt: pilarvargas-tecnativa
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-Yajo| 
+|maintainer-pilarvargas-tecnativa| 
 
 This module is part of the `OCA/event <https://github.com/OCA/event/tree/17.0/website_event_filter_city>`_ project on GitHub.
 

--- a/website_event_filter_city/__manifest__.py
+++ b/website_event_filter_city/__manifest__.py
@@ -11,7 +11,7 @@
     "Tecnativa, "
     "Onestein, "
     "Odoo Community Association (OCA)",
-    "maintainers": ["Yajo"],
+    "maintainers": ["pilarvargas-tecnativa"],
     "license": "LGPL-3",
     "installable": True,
     "depends": ["website_event"],

--- a/website_event_filter_city/static/description/index.html
+++ b/website_event_filter_city/static/description/index.html
@@ -451,7 +451,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/Yajo"><img alt="Yajo" src="https://github.com/Yajo.png?size=40px" /></a></p>
+<p><a class="reference external image-reference" href="https://github.com/pilarvargas-tecnativa"><img alt="pilarvargas-tecnativa" src="https://github.com/pilarvargas-tecnativa.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/event/tree/17.0/website_event_filter_city">OCA/event</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/website_event_filter_city/templates/event.xml
+++ b/website_event_filter_city/templates/event.xml
@@ -44,7 +44,7 @@
                 </div>
             </div>
         </xpath>
-        <xpath expr="//span[hasclass('o_wevent_offcanvas_country')]" position="after">
+        <xpath expr="//*[hasclass('o_wevent_offcanvas_country')]/.." position="after">
             <div class="accordion-item">
                 <h2 class="accordion-header">
                     <button


### PR DESCRIPTION
When the country filter is inactive, the node used is a span but when the country filter is activated with the editor, the node is replaced by a div and this causes an error. To avoid this, the node is replaced by something generic ‘*’ and so it will be located by its identifying class regardless of whether the element is a span or a div.

cc @tecnativa

@chienandalu @carlos-lopez-tecnativa  please review