### PR TITLE
[16.0][IMP] partner_event: use order in search by email

### DIFF
--- a/partner_event/models/event_registration.py
+++ b/partner_event/models/event_registration.py
@@ -39,7 +39,9 @@ class EventRegistration(models.Model):
             Event = self.env["event.event"]
             # Look for a partner with that email
             email = vals.get("email").replace("%", "").replace("_", "\\_")
-            attendee_partner = Partner.search([("email", "=ilike", email)], limit=1)
+            attendee_partner = Partner.search(
+                [("email", "=ilike", email)], limit=1, order="id"
+            )
             event = Event.browse()
             if vals.get("event_id"):
                 event = Event.browse(vals["event_id"])


### PR DESCRIPTION
The search by email is limited to 1 record and without the order clause is using the default order that is defined in https://github.com/odoo/odoo/blob/7f3863bdeb21ecfb7ac1859641bddf3de5dd8643/odoo/addons/base/models/res_partner.py#L178 and it could be customized. 

Since the default order could cause a slow query this adds an "order" clause in the search to prevent the use of the default order and use the ID instead.

For example, in this case where without the order clause is using display_name in the order by default:

![Screenshot 2025-01-29 at 12 42 48 p m](https://github.com/user-attachments/assets/a59f8e54-e1ca-4bc7-b254-9e86efe1fca1)

The partner result of the search must match with the email search, so any result is useful for this case.
