### PR TITLE
[IMP] partner_event: use order in search by email

### DIFF
--- a/partner_event/models/event_registration.py
+++ b/partner_event/models/event_registration.py
@@ -40,7 +40,9 @@ class EventRegistration(models.Model):
             Event = self.env["event.event"]
             # Look for a partner with that email
             email = vals.get("email").replace("%", "").replace("_", "\\_")
-            attendee_partner = Partner.search([("email", "=ilike", email)], limit=1)
+            attendee_partner = Partner.search(
+                [("email", "=ilike", email)], limit=1, order="id"
+            )
             event = Event.browse()
             if vals.get("event_id"):
                 event = Event.browse(vals["event_id"])


### PR DESCRIPTION
The search by email is limited to 1 record and without the order clause uses the default order that is defined in
https://github.com/odoo/odoo/blob/7f3863bdeb21ecfb7ac1859641bddf3de5dd8643/odoo/addons/base/models/res_partner.py#L178 and it could be customized since the default order could cause a slow query this adds an "order" clause in the search to prevent the use of the default order and use the ID instead.

The partner got from the search must match the email searched, so any result is useful for this case.

Forward port of https://github.com/OCA/event/pull/428/commits