### PR TITLE
[15.0][FIX] partner_event: Restrict the event registration counter button to authorised users only.

### DIFF
--- a/partner_event/views/res_partner_view.xml
+++ b/partner_event/views/res_partner_view.xml
@@ -15,6 +15,10 @@
         <field name="name">Partner Form with registrations</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('event.group_event_registration_desk'))]"
+        />
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <button


### PR DESCRIPTION
Added the "event.group_event_registration_desk" group to the partner form view. This prevents access errors for users who do not have permission to read "event.registration" records.
By restricting the view to authorized users, the computed field "registration_count" is not evaluated for unauthorized users, avoiding security warnings.

![image](https://github.com/user-attachments/assets/92f8cf10-b5d4-4378-9b45-076cb02ab1fc)


@victoralmau @pedrobaeza please review