### PR TITLE
[16.0][IMP] partner_event: search partner by linked event

### DIFF
--- a/partner_event/views/res_partner_view.xml
+++ b/partner_event/views/res_partner_view.xml
@@ -29,4 +29,18 @@
             </div>
         </field>
     </record>
+    <record id="view_res_partner_filter" model="ir.ui.view">
+        <field name="name">res.partner.select</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter" />
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field
+                    name="event_registration_ids"
+                    string="Linked events"
+                    filter_domain="[('event_registration_ids.event_id', 'ilike', self)]"
+                />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Searching partner per event is listed in README (Search partners by their event attendees) but is not working (since event_registration_ids on partner links to event.registration table where name is name of the attendee and not name of the event).

This PR adds in search view a filter on event.