### PR TITLE
[16.0][FIX] event_session: ux_view on event_type

### DIFF
--- a/event_session/views/event_type.xml
+++ b/event_session/views/event_type.xml
@@ -5,10 +5,10 @@
         <field name="model">event.type</field>
         <field name="inherit_id" ref="event.view_event_type_form" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//field[@name='has_seats_limitation']/parent::div"
-                position="before"
-            >
+            <xpath 
+                expr="//field[@name='auto_confirm']"
+                position="after"
+                >
                 <div colspan="2" class="o_checkbox_optional_field">
                     <label for="use_sessions" />
                     <field name="use_sessions" class="w-100" />


### PR DESCRIPTION
The event model view was broken in its layout. An empty checkbox appears in the right-hand column, followed by the autoconfirmation text, which is not aligned with its own checkbox.

Before : 
![image](https://github.com/user-attachments/assets/8f736ee4-acb5-41d3-8cdd-b05ef880377e)


After : 
![image(4)](https://github.com/user-attachments/assets/5af21912-eeb7-4ea5-b8b4-08876db355a5)
