### PR TITLE
[17.0][FIX] partner_event: Avoid contact error

### DIFF
--- a/partner_event/README.rst
+++ b/partner_event/README.rst
@@ -33,16 +33,16 @@ smart button.
 
 It also includes:
 
-- Search partners by their event attendees.
-- Search partners by number of events attendees.
-- Search partners by number of events attended.
-- Partner column is visible on registration one2many list inside the
-  event.
-- Action in partner tree view 'More' button, to register several
-  partners to an event
-- Restricts partner deletion when event attendees are linked to it.
-- Onchange for partner_id removed in v16 core in Event Registration-
-  including functionality here
+-  Search partners by their event attendees.
+-  Search partners by number of events attendees.
+-  Search partners by number of events attended.
+-  Partner column is visible on registration one2many list inside the
+   event.
+-  Action in partner tree view 'More' button, to register several
+   partners to an event
+-  Restricts partner deletion when event attendees are linked to it.
+-  Onchange for partner_id removed in v16 core in Event Registration-
+   including functionality here
 
 **Table of contents**
 
@@ -85,23 +85,24 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pedro M. Baeza
-  - Antonio Espinosa
-  - Jairo Llopis
-  - Vicent Cubells
-  - David Vidal
-  - Rafael Blasco
-  - Víctor Martínez
-  - Stefan Ungureanu
-  - Carolina Fernandez
+   -  Pedro M. Baeza
+   -  Antonio Espinosa
+   -  Jairo Llopis
+   -  Vicent Cubells
+   -  David Vidal
+   -  Rafael Blasco
+   -  Víctor Martínez
+   -  Stefan Ungureanu
+   -  Carolina Fernandez
+   -  Pilar Vargas
 
-- `Antiun <https://antiun.com/>`__:
+-  `Antiun <https://antiun.com/>`__:
 
-  - Javier Iniesta
+   -  Javier Iniesta
 
-- Anil Kesariya
+-  Anil Kesariya
 
 Maintainers
 -----------

--- a/partner_event/readme/CONTRIBUTORS.md
+++ b/partner_event/readme/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
   - Víctor Martínez
   - Stefan Ungureanu
   - Carolina Fernandez
+  - Pilar Vargas
 - [Antiun](https://antiun.com/):
   - Javier Iniesta
 - Anil Kesariya

--- a/partner_event/static/description/index.html
+++ b/partner_event/static/description/index.html
@@ -439,6 +439,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Víctor Martínez</li>
 <li>Stefan Ungureanu</li>
 <li>Carolina Fernandez</li>
+<li>Pilar Vargas</li>
 </ul>
 </li>
 <li><a class="reference external" href="https://antiun.com/">Antiun</a>:<ul>

--- a/partner_event/views/res_partner_view.xml
+++ b/partner_event/views/res_partner_view.xml
@@ -21,6 +21,7 @@
                     name="%(partner_event.act_partner_registration)d"
                     type="action"
                     class="oe_stat_button oe_inline"
+                    groups="event.group_event_user"
                     help="Count of events with confirmed registrations."
                     icon="fa-id-card"
                 >


### PR DESCRIPTION
A user accessing contacts without event access permission will get an event.registration access error. To avoid this, the event user group is added to the event.registration button of the res.partner form.

@victoralmau @juancarlosonate-tecnativa please review

```
2025-05-16 10:15:47,842 47 [1;33m[1;49mWARNING[0m prod odoo.http: You are not allowed to access 'Event Registration' (event.registration) records.

This operation is allowed for the following groups:
	- Events/Administrator
	- Events/Registration Desk

Contact your administrator to request access if necessary. 