### PR TITLE
[15.0][FIX] sale_crm_event_reservation: Validate partner before creating order with Form to respect blocks

### DIFF
--- a/sale_crm_event_reservation/wizards/crm_lead_event_sale_wizard.py
+++ b/sale_crm_event_reservation/wizards/crm_lead_event_sale_wizard.py
@@ -100,11 +100,20 @@ class CRMLeadEventSale(models.TransientModel):
         # Creating a sale order properly involves lots of onchanges, so here it
         # is better to use `Form` to make sure we forget none
         so_form = Form(self.env["sale.order"])
+        so_form.partner_id = self.opportunity_id.partner_id
+        # If the partner has configured a warning that blocks, the partner won't be
+        # assigned here, so let's redirects to the standard action of creating a quote
+        # from the opportunity, passing the `default_partner_id` context to follow the
+        # Odoo flow, thus displaying the block message normally and avoiding errors in
+        # creation.
+        if not so_form.partner_id:
+            return self.opportunity_id.with_context(
+                default_partner_id=self.opportunity_id.partner_id.id
+            ).action_new_quotation()
         so_form.campaign_id = self.opportunity_id.campaign_id
         so_form.medium_id = self.opportunity_id.medium_id
         so_form.opportunity_id = self.opportunity_id
         so_form.origin = self.opportunity_id.name
-        so_form.partner_id = self.opportunity_id.partner_id
         so_form.source_id = self.opportunity_id.source_id
         so_form.team_id = self.opportunity_id.team_id
         with so_form.order_line.new() as so_line:


### PR DESCRIPTION
@Tecnativa 

Manage partner blocking when creating orders with Form, redirecting to standard action if there is no partner.
Order creation with Form is maintained and partner blocking is handled with conditional redirection to ensure that order lines are created correctly and all associated logic is executed, which does not happen if the standard action `action_new_quotation` is used, which only creates the order without lines.
However, when using `Form`, if the contact has a blocking message that prevents the partner from being assigned, order creation fails with a required field error. To avoid this, a conditional is added that detects if the partner could not be assigned in the form, and in that case, it redirects to the standard action `action_new_quotation`, passing the partner via context (`default_partner_id`) so that the blocking message is displayed normally, respecting the Odoo flow.
This achieves the following:
- Create the order with lines correctly when possible.
- Display the partner block if necessary without throwing errors.
- Do not lose the basic Odoo validation.

<img width="731" height="819" alt="image" src="https://github.com/user-attachments/assets/04e1a915-c9bc-4372-897d-aa6b3d2d206b" />

@pedrobaeza @victoralmau please review