### PR TITLE
[17.0][FIX] sale_crm_event_reservation: Compare datetime properly

### DIFF
--- a/sale_crm_event_reservation/wizards/crm_lead_event_sale_wizard.py
+++ b/sale_crm_event_reservation/wizards/crm_lead_event_sale_wizard.py
@@ -93,7 +93,7 @@ class CRMLeadEventSale(models.TransientModel):
                 tickets = record.event_id.event_ticket_ids.filtered(
                     lambda ticket, record=record: (
                         not ticket.end_sale_datetime
-                        or ticket.end_sale_datetime >= fields.Date.context_today(self)
+                        or ticket.end_sale_datetime >= fields.Datetime.now()
                     )
                     and (
                         not ticket.seats_limited


### PR DESCRIPTION
Don't compare a date with a datetime field:

```
File "/opt/odoo/auto/addons/sale_crm_event_reservation/wizards/crm_lead_event_sale_wizard.py", line 96, in <lambda>
  or ticket.end_sale_datetime >= fields.Date.context_today(self)
TypeError: can't compare datetime.datetime to datetime.date
```

@Tecnativa TT57560