### PR TITLE
[18.0][FIX] event_sale_registration_multi_qty: adapt tests to upstream change

### DIFF
--- a/event_sale_registration_multi_qty/tests/test_event_sale_registration_multi_qty.py
+++ b/event_sale_registration_multi_qty/tests/test_event_sale_registration_multi_qty.py
@@ -89,7 +89,7 @@ class TestEventSaleRegistrationMultiQty(BaseCommon):
         for reg in regs:
             self.assertEqual(reg.qty, 1)
             self.assertEqual(reg.event_id, self.event_nomulti)
-            self.assertEqual(reg.state, "open")
+            self.assertEqual(reg.state, "draft")
 
     def test_sale_mixed(self):
         sale = self._create_sale().save()
@@ -103,7 +103,7 @@ class TestEventSaleRegistrationMultiQty(BaseCommon):
         regs = self.env["event.registration"].search([("sale_order_id", "=", sale.id)])
         self.assertEqual(len(regs), 6)
         for reg in regs:
-            self.assertEqual(reg.state, "open")
+            self.assertIn(reg.state, ("draft", "open"))
             if reg.event_id == self.event_multi:
                 self.assertEqual(reg.qty, 5)
             else:


### PR DESCRIPTION
since https://github.com/OCA/OCB/commit/ba6f21fe884f53e5bcba5aa9bfd376288ab08bf1, event registrations from sale orders aren't autoconfirmed