### PR TITLE
[18.0][IMP] partner_event: Add create attendee partner button  from registration

### DIFF
--- a/partner_event/models/event_registration.py
+++ b/partner_event/models/event_registration.py
@@ -8,6 +8,7 @@
 # Copyright 2024 Tecnativa - Juan José Seguí
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 
 
 class EventRegistration(models.Model):
@@ -22,6 +23,7 @@ class EventRegistration(models.Model):
         index=True,
     )
 
+    @api.model
     def _prepare_partner(self, vals):
         return {
             "name": vals.get("name") or vals.get("email"),
@@ -29,6 +31,27 @@ class EventRegistration(models.Model):
             "phone": vals.get("phone", False),
         }
 
+    def action_create_attendee_partner(self):
+        self.ensure_one()
+        if self.attendee_partner_id:
+            return True
+        if not self.name and not self.email:
+            raise UserError(
+                self.env._(
+                    "Set at least the attendee name or email before creating a partner."
+                )
+            )
+        keys = self._prepare_partner({}).keys()
+        attendee_partner = self.env["res.partner"].create(
+            self._prepare_partner({field_name: self[field_name] for field_name in keys})
+        )
+        vals = {"attendee_partner_id": attendee_partner.id}
+        if not self.partner_id:
+            vals["partner_id"] = attendee_partner.id
+        self.write(vals)
+        return True
+
+    @api.model
     def _update_attendee_partner_id(self, vals):
         # Don't update if doing a partner merging
         if (

--- a/partner_event/views/event_registration_view.xml
+++ b/partner_event/views/event_registration_view.xml
@@ -8,7 +8,18 @@
         <field name="inherit_id" ref="event.view_event_registration_form" />
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="attendee_partner_id" />
+                <label for="attendee_partner_id" class="o_form_label" />
+                <div class="o_row">
+                    <field name="attendee_partner_id" />
+                    <button
+                        name="action_create_attendee_partner"
+                        icon="fa-plus-square"
+                        string="Create Partner"
+                        type="object"
+                        class="oe_edit_only btn-link"
+                        invisible="attendee_partner_id or (not name and not email)"
+                    />
+                </div>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Before:
<img width="632" height="405" alt="image" src="https://github.com/user-attachments/assets/e1299590-5c79-4e45-94b1-918aefece4a1" />

After:
<img width="563" height="362" alt="image" src="https://github.com/user-attachments/assets/70fcc588-3cf9-4581-aaaf-508e94c89a79" />

When using the button, name, email and phone is automatically added to the created contact.