### PR TITLE
[19.0][IMP] event_registration_cancel_reason: Improve cancellation wi…

### DIFF
--- a/event_registration_cancel_reason/wizard/event_registration_cancel_log_reason_view.xml
+++ b/event_registration_cancel_reason/wizard/event_registration_cancel_log_reason_view.xml
@@ -4,13 +4,13 @@
         <field name="name">Logging registration cancellation wizard</field>
         <field name="model">event.registration.cancel.log.reason</field>
         <field name="arch" type="xml">
-            <form name="">
-                <field name="event_type_id" invisible="1" />
-                <label
-                    for="reason_id"
-                    string="Select the reason for cancelling the registration:"
-                />
-                <field name="reason_id" />
+            <form>
+                <group name="registration_cancel">
+                    <group name="cancel_reason">
+                        <field name="event_type_id" invisible="1" />
+                        <field name="reason_id" string="Reason" />
+                    </group>
+                </group>
                 <footer>
                     <button
                         name="button_log"


### PR DESCRIPTION
This PR improves the layout of the registration cancellation wizard by using a standard group-based form layout instead of a standalone label and field.

No functional changes are introduced; this only enhances the visual presentation of the wizard form.

