### PR TITLE
[18.0][FIX] website_event_filter_city: remove test key from tour

### DIFF
--- a/website_event_filter_city/static/src/js/website_event_filter_city_tour.esm.js
+++ b/website_event_filter_city/static/src/js/website_event_filter_city_tour.esm.js
@@ -5,7 +5,6 @@
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_event_filter_city", {
-    test: true,
     url: "/event",
     steps: () => [
         {


### PR DESCRIPTION
the [schema](https://github.com/odoo/odoo/blob/18.0/addons/web_tour/static/src/tour_service/tour_service.js#L46) doesn't contain this key, so this fails on validation