### PR TITLE
[19.0][FIX] partner_event: Write back registration info from partner with sudo

### DIFF
--- a/partner_event/models/res_partner.py
+++ b/partner_event/models/res_partner.py
@@ -32,7 +32,7 @@ class ResPartner(models.Model):
 
     def write(self, data):
         res = super().write(data)
-        self.mapped("event_registration_ids").partner_data_update(data)
+        self.sudo().event_registration_ids.partner_data_update(data)
         return res
 
     def address_get(self, adr_pref=None):


### PR DESCRIPTION
Event registrations can be handled only by event users (read/write), so writing any field in the partner triggers this problem.

```
  File "/opt/odoo/auto/addons/partner_event/models/res_partner.py", line 35, in write
    self.mapped("event_registration_ids").partner_data_update(data)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
    field.read(fetched)
  File "/opt/odoo/custom/src/odoo/odoo/orm/fields_relational.py", line 956, in read
    raise AccessError(records.env._("Failed to read field %s", self) + '\n' + str(e)) from e
odoo.exceptions.AccessError: Failed to read field res.partner.event_registration_ids
You are not allowed to access 'Event Registration' (event.registration) records.
This operation is allowed for the following groups:
	- Events/Administrator
	- Events/Registration Desk
Contact your administrator to request access if necessary.
````

This has not been discovered before in the test suite, because previously, if Odoo doesn't return any record, the error was not triggered, but now in 19, the access permission is checked no matter if there are records or not.

@Tecnativa TT63973