### PR TITLE
[16.0][FIX] event_registration_multi_qty: sudo read_group in compute_seats

### DIFF
--- a/event_registration_multi_qty/models/event.py
+++ b/event_registration_multi_qty/models/event.py
@@ -23,13 +23,17 @@ class EventEvent(models.Model):
                 "seats_used": 0,
                 "seats_available": 0,
             }
-            registrations = self.env["event.registration"].read_group(
-                [
-                    ("event_id", "=", event.id),
-                    ("state", "in", ["draft", "open", "done"]),
-                ],
-                ["state", "qty"],
-                ["state"],
+            registrations = (
+                self.env["event.registration"]
+                .sudo()
+                .read_group(
+                    [
+                        ("event_id", "=", event.id),
+                        ("state", "in", ["draft", "open", "done"]),
+                    ],
+                    ["state", "qty"],
+                    ["state"],
+                )
             )
             for registration in registrations:
                 if registration["state"] == "draft":


### PR DESCRIPTION
`super` uses [SQL](https://github.com/OCA/OCB/blob/16.0/addons/event/models/event_event.py#L249) to read from the event.registration model, so this function works without read access to event.registration. Any override should behave the same.

Without this patch, you can't use event_registration_multi_qty in conjunction with website_event_sale and limited seats.