### PR TITLE
[19.0][FIX] event_sale_reservation: Compatibility with sale_project

### DIFF
--- a/event_sale_reservation/models/sale_order_line.py
+++ b/event_sale_reservation/models/sale_order_line.py
@@ -25,6 +25,19 @@ class SaleOrderLine(models.Model):
         store=True,
     )
 
+    @api.depends("event_reservation_type_id")
+    def _compute_product_updatable(self):
+        event_registration_lines = self.filtered("event_reservation_type_id")
+        # Exclude event registration lines from the computation of product_updatable.
+        # If sale_project is installed, this module sets product_updatable to True for
+        # service products on confirmed sale orders, preventing the product from being
+        # changed when the reservation is converted to an event registration.
+        # This workaround allows the product to be changed in that case.
+        self -= event_registration_lines
+        res = super()._compute_product_updatable()
+        event_registration_lines.product_updatable = True
+        return res
+
     @api.depends("event_registration_ids")
     def _compute_event_registration_count(self):
         """Get count of related event registrations."""


### PR DESCRIPTION
The `sale_project` module overrides [_compute_product_updatable](https://github.com/odoo/odoo/blob/fc175e12da696f2c23842af8df3af9939512f3f9/addons/sale_project/models/sale_order_line.py#L68) and sets it to `False` when the product is a `service` and the sale order is `confirmed`.

When a product created for an event reservation is a service and the sale order is confirmed, an error is raised when trying to register for the event, indicating that the product cannot be changed on the sale order line.

As there is no explicit dependency on sale_project, the sale_project method is called first.

**Steps to reproduce:**

Create a sale order with a product for reservation. Confirm the order.
Click Register in event.
Select the event and click Next.
The error is displayed.
<img width="1612" height="882" alt="image" src="https://github.com/user-attachments/assets/43461fbd-30c9-4d9f-a002-0f9bc3c97426" />

@Tecnativa @pedrobaeza @pilarvargas-tecnativa could you please review this?